### PR TITLE
feat: establish typography foundation with Outfit/Crimson Pro

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,3 +8,54 @@ body {
   padding: 0;
 }
 
+:root {
+  --font-display: 'Outfit', sans-serif;
+  --font-body: 'Crimson Pro', serif;
+}
+
+body {
+  font-family: var(--font-body);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+/* Typographic hierarchy */
+h1 {
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+h2 {
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  font-size: 0.875em;
+  letter-spacing: 0.15em;
+  opacity: 0.7;
+}
+
+/* Section titles - larger, more dramatic */
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: 3rem;
+  letter-spacing: -0.02em;
+  position: relative;
+}
+
+/* Geometric accent line under section titles */
+.section-title::after {
+  content: '';
+  display: block;
+  width: 60px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--blue-9), transparent);
+  margin-top: 1rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,21 @@
 import "@radix-ui/themes/styles.css";
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
-import { Inter } from "next/font/google";
+import { Outfit, Crimson_Pro } from "next/font/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Theme } from "@radix-ui/themes";
 
-const inter = Inter({ subsets: ["latin"] })
+const outfit = Outfit({
+  subsets: ["latin"],
+  variable: "--font-display",
+  display: "swap",
+});
+
+const crimsonPro = Crimson_Pro({
+  subsets: ["latin"],
+  variable: "--font-body",
+  display: "swap",
+});
 
 export const metadata = {
   title: "Rob Abby - Product Engineer",
@@ -19,7 +29,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${outfit.variable} ${crimsonPro.variable}`}>
         <Theme appearance="dark">
           {children}
         </Theme>


### PR DESCRIPTION
Phase 1 of Sacred Geometry redesign (SG-95):
- Replace Inter with Outfit (display) and Crimson Pro (body) fonts
- Add CSS custom properties for font families
- Establish typographic hierarchy with heading styles
- Add .section-title class with geometric accent line

🤖 Generated with [Claude Code](https://claude.com/claude-code)