### PR TITLE
feat: redesign nav with glass-morphism dark theme

### DIFF
--- a/app/components/Header/style.css
+++ b/app/components/Header/style.css
@@ -24,33 +24,42 @@ p {
 .NavigationMenuList {
 	display: flex;
 	justify-content: center;
-	background-color: white;
-	padding: 4px;
-	border-radius: 6px;
+	background: rgba(15, 20, 30, 0.85);
+	backdrop-filter: blur(12px);
+	-webkit-backdrop-filter: blur(12px);
+	padding: 6px 8px;
+	border-radius: 999px;
 	list-style: none;
-	box-shadow: 0 2px 10px var(--black-a7);
+	border: 1px solid rgba(100, 150, 255, 0.15);
+	box-shadow:
+		0 4px 24px rgba(0, 0, 0, 0.4),
+		inset 0 1px 0 rgba(255, 255, 255, 0.05);
 	margin: 0;
 }
 
 .NavigationMenuTrigger,
 .NavigationMenuLink {
-	padding: 8px 12px;
+	padding: 10px 16px;
 	outline: none;
 	user-select: none;
+	font-family: var(--font-display);
 	font-weight: 500;
 	line-height: 1;
-	border-radius: 4px;
-	font-size: 15px;
-	color: var(--blue-9);
+	border-radius: 999px;
+	font-size: 14px;
+	color: rgba(255, 255, 255, 0.7);
+	transition: all 0.2s ease;
 }
+
 .NavigationMenuTrigger:focus,
 .NavigationMenuLink:focus {
-	box-shadow: 0 0 0 2px var(--violet-7);
+	box-shadow: 0 0 0 2px rgba(100, 150, 255, 0.4);
 }
+
 .NavigationMenuTrigger:hover,
 .NavigationMenuLink:hover {
-	background-color: var(--blue-3);
-	color: var(--blue-11);
+	background: rgba(100, 150, 255, 0.15);
+	color: rgba(255, 255, 255, 1);
 }
 
 .NavigationMenuTrigger {


### PR DESCRIPTION
Phase 2 of Sacred Geometry redesign (SG-96):
- Replace white background with translucent dark glass
- Add backdrop blur effect
- Update to pill-shaped container and links
- Add subtle blue-tinted border glow
- Update hover/focus states for dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)