### PR TITLE
feat: add parallax depth and ambient particles to Hero section (Phase 5)

### DIFF
--- a/app/components/AmbientParticles/index.tsx
+++ b/app/components/AmbientParticles/index.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+import { useMemo } from "react";
+import "./style.css";
+
+type Particle = {
+  id: number;
+  x: number;
+  y: number;
+  size: number;
+  opacity: number;
+  duration: number;
+  delay: number;
+};
+
+type AmbientParticlesProps = {
+  count?: number;
+  minSize?: number;
+  maxSize?: number;
+  minOpacity?: number;
+  maxOpacity?: number;
+  className?: string;
+};
+
+export default function AmbientParticles({
+  count = 20,
+  minSize = 3,
+  maxSize = 8,
+  minOpacity = 0.1,
+  maxOpacity = 0.4,
+  className = ""
+}: AmbientParticlesProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const particles = useMemo<Particle[]>(() => {
+    return Array.from({ length: count }, (_, i) => ({
+      id: i,
+      x: Math.random() * 100,
+      y: Math.random() * 100,
+      size: minSize + Math.random() * (maxSize - minSize),
+      opacity: minOpacity + Math.random() * (maxOpacity - minOpacity),
+      duration: 10 + Math.random() * 10,
+      delay: Math.random() * 5
+    }));
+  }, [count, minSize, maxSize, minOpacity, maxOpacity]);
+
+  return (
+    <div className={`ambient-particles ${className}`}>
+      {!prefersReducedMotion && particles.map((particle) => (
+        <motion.div
+          key={particle.id}
+          className="particle"
+          style={{
+            left: `${particle.x}%`,
+            top: `${particle.y}%`,
+            width: particle.size,
+            height: particle.size,
+            opacity: particle.opacity
+          }}
+          animate={{
+            y: particle.id % 2 === 0 ? [-20, 20] : [0, 40],
+            x: particle.id % 3 === 0 ? [-10, 10] : [0, 0]
+          }}
+          transition={{
+            duration: particle.duration,
+            delay: particle.delay,
+            repeat: Infinity,
+            repeatType: "reverse",
+            ease: "easeInOut"
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/app/components/AmbientParticles/style.css
+++ b/app/components/AmbientParticles/style.css
@@ -1,0 +1,14 @@
+.ambient-particles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.particle {
+  position: absolute;
+  border-radius: 50%;
+  background: var(--sg-primary);
+  pointer-events: none;
+}

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -2,46 +2,78 @@
 
 import { Box, Container, Flex, Heading, IconButton, Link, Section, Text } from "@radix-ui/themes";
 import { EnvelopeClosedIcon, GitHubLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
-// import { FileIcon } from "@radix-ui/react-icons";
+import { motion, useScroll, useTransform, useReducedMotion } from "motion/react";
+import { useRef } from "react";
 import MetatronsCube from "./MetatronsCube";
+import AmbientParticles from "./AmbientParticles";
 import "./Hero.css";
 
 export default function Hero() {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start start", "end start"]
+  });
+
+  const cubeY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    [0, prefersReducedMotion ? 0 : 150]
+  );
+
+  const textY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    [0, prefersReducedMotion ? 0 : 50]
+  );
+
+  const opacity = useTransform(
+    scrollYProgress,
+    [0, 0.5],
+    [1, prefersReducedMotion ? 1 : 0]
+  );
+
   return (
-    <Section id="home" style={{ background: "var(--blue-a9)", position: "relative" }}>
-      <Box py="9">
-        <MetatronsCube />
-        <Container py="8" size="3" style={{ position: "relative", zIndex: 1 }}>
-          <Flex direction="column" gap="4" align="center">
-            <Heading mb="4" size="9">Robert Abby</Heading>
-            <Text mb="4" size="7">Product Engineer</Text>
-            <Flex direction="row" gap="4" mb="4">
-              <Link href="https://www.linkedin.com/in/robabby/" target="_blank">
-                <IconButton size="3" style={{ cursor: "pointer" }}>
-                  <LinkedInLogoIcon />
-                </IconButton>
-              </Link>
-              <Link href="https://github.com/robabby" target="_blank">
-                <IconButton size="3" style={{ cursor: "pointer" }}>
-                  <GitHubLogoIcon />
-                </IconButton>
-              </Link>
-              <Link href="mailto:robabby23@gmail.com">
-                <IconButton size="3" style={{ cursor: "pointer" }}>
-                  <EnvelopeClosedIcon />
-                </IconButton>
-              </Link>
+    <Section
+      ref={sectionRef}
+      id="home"
+      style={{ background: "var(--blue-a9)", position: "relative", overflow: "hidden" }}
+    >
+      <Box py="9" style={{ position: "relative" }}>
+        <AmbientParticles />
+
+        <motion.div style={{ y: cubeY, opacity }}>
+          <MetatronsCube />
+        </motion.div>
+
+        <motion.div style={{ y: textY, opacity, position: "relative", zIndex: 1 }}>
+          <Container py="8" size="3">
+            <Flex direction="column" gap="4" align="center">
+              <Heading mb="4" size="9">Robert Abby</Heading>
+              <Text mb="4" size="7">Product Engineer</Text>
+              <Flex direction="row" gap="4" mb="4">
+                <Link href="https://www.linkedin.com/in/robabby/" target="_blank">
+                  <IconButton size="3" style={{ cursor: "pointer" }}>
+                    <LinkedInLogoIcon />
+                  </IconButton>
+                </Link>
+                <Link href="https://github.com/robabby" target="_blank">
+                  <IconButton size="3" style={{ cursor: "pointer" }}>
+                    <GitHubLogoIcon />
+                  </IconButton>
+                </Link>
+                <Link href="mailto:robabby23@gmail.com">
+                  <IconButton size="3" style={{ cursor: "pointer" }}>
+                    <EnvelopeClosedIcon />
+                  </IconButton>
+                </Link>
+              </Flex>
             </Flex>
-            {/* <Button asChild size="4">
-              <Link href="/robert-abby-resume.pdf" target="_blank">
-                <FileIcon />
-                <Text>R&eacute;sum&eacute;</Text>
-              </Link>
-            </Button> */}
-          </Flex>
-        </Container>
+          </Container>
+        </motion.div>
       </Box>
     </Section>
-  )
+  );
 }
-


### PR DESCRIPTION
- Add scroll-based parallax: MetatronsCube moves 150px, text moves 50px
- Both elements fade to opacity 0 as user scrolls past hero
- Create reusable AmbientParticles component with 20 floating circles
- Use --sg-primary color for particles matching sacred geometry theme
- Respect prefers-reduced-motion accessibility setting throughout
- Fix SSR hydration by always rendering container in AmbientParticles

🤖 Generated with [Claude Code](https://claude.com/claude-code)