### PR TITLE
feat: add sacred geometry card and component styling (Phase 6)

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -9,7 +9,7 @@ export default function About() {
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
         <Flex direction="column" justify="center" align="center">
           <Heading mb="4" size="8">About</Heading>
-          <Container p="4" mx="4" my="8" size="3" style={{ background: "var(--gray-a3)", borderRadius: "var(--radius-3)" }}>
+          <Container p="4" mx="4" my="8" size="3" className="sg-card">
             <Text size="4">
               I have 15 years of experience building performant, user-centered web applications across B2B and B2C domains
               in agile software development teams. I specialize in React frameworks and excel at translating complex technical

--- a/app/components/Experience/components/ExperienceItem/index.tsx
+++ b/app/components/Experience/components/ExperienceItem/index.tsx
@@ -33,7 +33,7 @@ export default function Experience({
       open={isOpen}
       onOpenChange={setIsOpen}
     >
-      <Container p="4" mx="4" my="8" size="3" style={{ background: "var(--gray-a3)", borderRadius: "var(--radius-3)" }}>
+      <Container p="4" mx="4" my="8" size="3" className="sg-card">
         <Heading size="6">{title}</Heading>
         <Flex direction="row" justify="between" my="2">
           <Text>

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -68,17 +68,13 @@ export default function Projects() {
           Projects
         </Heading>
         {PROJECTS.map((proj, index) => (
-          <Container 
-            key={index} 
-            size="3" 
-            mx="4" 
-            mb="8" 
-            p="4" 
-            style={{ 
-              background: "var(--gray-a4)", 
-              borderRadius: "var(--radius-3)", 
-              boxShadow: "var(--shadow-3)" 
-            }}
+          <Container
+            key={index}
+            size="3"
+            mx="4"
+            mb="8"
+            p="4"
+            className="sg-card"
           >
             <Heading mb="4" size="4">{proj.title}</Heading>
             {proj.callout && (

--- a/app/components/Skills.tsx
+++ b/app/components/Skills.tsx
@@ -33,7 +33,7 @@ export default function Skills() {
           <Container size="3">
             <Flex direction="column" gap="4">
               {Object.entries(SKILLS).map(([category, skills]) => (
-                <Box key={category} mx="4" p="4" style={{ background: "var(--gray-a3)", borderRadius: "var(--radius-3)" }}>
+                <Box key={category} mx="4" p="4" className="sg-card">
                   <Heading mb="4" size="5">{category}</Heading>
                   <StaggeredList style={{ display: "flex", flexDirection: "row", gap: "var(--space-2)", flexWrap: "wrap" }}>
                     {skills.map((skill, index) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -81,3 +81,54 @@ h2 {
   margin-right: auto;
 }
 
+/* Sacred geometry cards */
+.sg-card {
+  background: var(--sg-gradient-card);
+  border: 1px solid rgba(100, 150, 255, 0.1);
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.sg-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(74, 158, 255, 0.05) 0%,
+    transparent 50%
+  );
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.sg-card:hover {
+  border-color: rgba(100, 150, 255, 0.25);
+  transform: translateY(-2px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(74, 158, 255, 0.1);
+}
+
+.sg-card:hover::before {
+  opacity: 1;
+}
+
+/* Badge enhancements */
+.sg-badge {
+  background: rgba(74, 158, 255, 0.1);
+  border: 1px solid rgba(74, 158, 255, 0.2);
+  color: var(--sg-text-primary);
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  transition: all 0.2s ease;
+}
+
+.sg-badge:hover {
+  background: rgba(74, 158, 255, 0.2);
+  border-color: rgba(74, 158, 255, 0.4);
+}
+


### PR DESCRIPTION
## Summary

- Added `.sg-card` class with gradient background, subtle blue border glow, and hover effects (transform + shadow)
- Added `.sg-badge` class with ethereal blue styling and hover transitions  
- Applied `sg-card` styles to About, Skills, Experience, and Projects components
- Replaced inline styles with consistent CSS class for maintainability

## Test plan

- [ ] Verify cards have gradient background in About, Skills, Experience, Projects sections
- [ ] Hover over cards to confirm lift effect (translateY) and glow border
- [ ] Verify visual consistency across all sections
- [ ] Test responsive behavior at mobile/tablet/desktop breakpoints

Closes SG-100

🤖 Generated with [Claude Code](https://claude.com/claude-code)