### PR TITLE
Phase 7: Footer & Final Polish (SG-101)

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,29 +1,85 @@
 import { Box, Container, Flex, Link, Text } from "@radix-ui/themes";
-import { LinkedInLogoIcon, GitHubLogoIcon, EnvelopeClosedIcon } from "@radix-ui/react-icons";
+import {
+  LinkedInLogoIcon,
+  GitHubLogoIcon,
+  EnvelopeClosedIcon,
+} from "@radix-ui/react-icons";
 
 export default function Footer() {
   return (
-    <Container px="6">
-      <Flex direction="column" justify="between" align="center" my="4">
-        <Box mb="4">
-          <Flex direction="row" align="center" gap="2">
-            <Link href="https://linkedin.com/in/robabby" target="_blank" rel="noopener noreferrer">
-              <LinkedInLogoIcon />&nbsp;
-              LinkedIn
-            </Link>
-            <Link href="https://github.com/robabby" target="_blank" rel="noopener noreferrer">
-              <GitHubLogoIcon />&nbsp;
-              GitHub
-            </Link>
-            <Link href="mailto:robabby23@gmail.com" target="_blank" rel="noopener noreferrer">
-              <EnvelopeClosedIcon />&nbsp;
-              Email
-            </Link>
-          </Flex>
-        </Box>
-        <Text>&copy; {new Date().getFullYear()} Rob Abby. All rights reserved.</Text>
-      </Flex>
-    </Container>
-  )
-}
+    <Box
+      asChild
+      style={{
+        background: "var(--sg-void)",
+        borderTop: "1px solid rgba(74, 158, 255, 0.1)",
+      }}
+    >
+      <footer>
+        {/* Geometric divider */}
+        <Box
+          style={{
+            height: "1px",
+            background:
+              "linear-gradient(90deg, transparent, var(--sg-primary), transparent)",
+            opacity: 0.3,
+          }}
+        />
 
+        <Container px="6" py="8">
+          <Flex direction="column" justify="between" align="center" gap="4">
+            <Flex direction="row" align="center" gap="4">
+              <Link
+                href="https://linkedin.com/in/robabby"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: "var(--sg-text-secondary)",
+                  transition: "color 0.2s",
+                }}
+                className="footer-link"
+              >
+                <Flex align="center" gap="1">
+                  <LinkedInLogoIcon />
+                  <Text size="2">LinkedIn</Text>
+                </Flex>
+              </Link>
+              <Link
+                href="https://github.com/robabby"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: "var(--sg-text-secondary)",
+                  transition: "color 0.2s",
+                }}
+                className="footer-link"
+              >
+                <Flex align="center" gap="1">
+                  <GitHubLogoIcon />
+                  <Text size="2">GitHub</Text>
+                </Flex>
+              </Link>
+              <Link
+                href="mailto:robabby23@gmail.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: "var(--sg-text-secondary)",
+                  transition: "color 0.2s",
+                }}
+                className="footer-link"
+              >
+                <Flex align="center" gap="1">
+                  <EnvelopeClosedIcon />
+                  <Text size="2">Email</Text>
+                </Flex>
+              </Link>
+            </Flex>
+            <Text size="1" style={{ color: "var(--sg-text-muted)" }}>
+              &copy; {new Date().getFullYear()} Rob Abby. All rights reserved.
+            </Text>
+          </Flex>
+        </Container>
+      </footer>
+    </Box>
+  );
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -60,8 +60,6 @@ export default function Footer() {
               </Link>
               <Link
                 href="mailto:robabby23@gmail.com"
-                target="_blank"
-                rel="noopener noreferrer"
                 style={{
                   color: "var(--sg-text-secondary)",
                   transition: "color 0.2s",

--- a/app/globals.css
+++ b/app/globals.css
@@ -132,3 +132,7 @@ h2 {
   border-color: rgba(74, 158, 255, 0.4);
 }
 
+/* Footer link styles */
+.footer-link:hover {
+  color: var(--sg-primary) !important;
+}


### PR DESCRIPTION
## Summary
- Enhanced Footer with sacred geometry styling (dark background, geometric gradient divider)
- Added hover transitions for footer links to primary color
- Used semantic `<footer>` element with Radix `asChild` pattern
- Completed final visual QA pass across all breakpoints (mobile, tablet, desktop)

## Changes
- `app/components/Footer.tsx` - Complete footer redesign with geometric styling
- `app/globals.css` - Added `.footer-link:hover` styles

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Footer displays correctly at desktop (1440px)
- [x] Footer displays correctly at tablet (768px)  
- [x] Footer displays correctly at mobile (375px)
- [x] Link hover states transition to primary blue
- [x] Geometric divider line visible

## Linear Issue
Closes SG-101

🤖 Generated with [Claude Code](https://claude.com/claude-code)