### PR TITLE
fix: add pointer-events: none to sg-card overlay

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,7 @@ h2 {
   );
   opacity: 0;
   transition: opacity 0.3s ease;
+  pointer-events: none;
 }
 
 .sg-card:hover {


### PR DESCRIPTION
## Summary
- Fixes buttons and links inside `.sg-card` components not being clickable
- Root cause: The `::before` pseudo-element overlay was intercepting pointer events
- Added `pointer-events: none` to allow clicks to pass through

## Test plan
- [x] Verified buttons in Projects section are now clickable
- [x] Hover effects on cards still work correctly

Closes SG-102

🤖 Generated with [Claude Code](https://claude.com/claude-code)