### PR TITLE
fix(ui): improve gold text contrast for better readability

### DIFF
--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -51,8 +51,8 @@ export default function Hero() {
         <motion.div style={{ y: textY, opacity, position: "relative", zIndex: 1 }}>
           <Container py="8" size="3">
             <Flex direction="column" gap="4" align="center">
-              <Heading mb="2" size="9">Rob Abby</Heading>
-              <Text size="7" style={{ color: "var(--sg-text-primary)" }}>Product Engineer</Text>
+              <Heading mb="2" size="9" style={{ textShadow: "0 2px 4px rgba(0, 0, 0, 0.3)" }}>Rob Abby</Heading>
+              <Text size="7" style={{ color: "var(--sg-text-primary)", textShadow: "0 1px 3px rgba(0, 0, 0, 0.3)" }}>Product Engineer</Text>
               <Text size="3" mb="4" style={{ color: "var(--sg-secondary)", letterSpacing: "0.1em", fontFamily: "var(--font-display)", textShadow: "0 1px 2px rgba(0, 0, 0, 0.3)" }}>
                 15+ Years Building Web Experiences
               </Text>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -53,7 +53,7 @@ export default function Hero() {
             <Flex direction="column" gap="4" align="center">
               <Heading mb="2" size="9">Rob Abby</Heading>
               <Text size="7" style={{ color: "var(--sg-text-primary)" }}>Product Engineer</Text>
-              <Text size="3" mb="4" style={{ color: "var(--sg-secondary)", letterSpacing: "0.1em", fontFamily: "var(--font-display)" }}>
+              <Text size="3" mb="4" style={{ color: "var(--sg-secondary)", letterSpacing: "0.1em", fontFamily: "var(--font-display)", textShadow: "0 1px 2px rgba(0, 0, 0, 0.3)" }}>
                 15+ Years Building Web Experiences
               </Text>
               <Flex direction="row" gap="4" mb="4">

--- a/app/globals.css
+++ b/app/globals.css
@@ -27,8 +27,8 @@ body {
   /* Accent colors - ethereal blues and golds */
   --sg-primary: #4a9eff;
   --sg-primary-glow: rgba(74, 158, 255, 0.4);
-  --sg-secondary: #c9a962;
-  --sg-secondary-glow: rgba(201, 169, 98, 0.3);
+  --sg-secondary: #d4b872;
+  --sg-secondary-glow: rgba(212, 184, 114, 0.3);
 
   /* Text */
   --sg-text-primary: rgba(255, 255, 255, 0.92);


### PR DESCRIPTION
## Summary
- Brighten gold accent color (`--sg-secondary`) from `#c9a962` to `#d4b872` for improved contrast
- Add subtle text shadow to Hero subtitle for additional legibility against the blue background
- Update glow color to match new gold value

## Test plan
- [ ] Verify Hero subtitle "15+ Years Building Web Experiences" is easier to read
- [ ] Check gold color displays well across all sections (badges, dates, accents)
- [ ] Confirm text shadow is subtle and doesn't overpower

Closes SG-130

🤖 Generated with [Claude Code](https://claude.com/claude-code)