### PR TITLE
feat(header): add statement piece navigation with animations and branding

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -1,25 +1,46 @@
 "use client";
 
-import { HomeIcon } from "@radix-ui/react-icons";
 import { NavigationMenu } from "radix-ui";
 import NextLink from "next/link";
 import { useEffect, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
 import "./style.css";
 
 const LINKS = [
-  { href: "#home", label: "Home" },
+  { href: "#home", label: "Home", isBrand: true },
   { href: "#about", label: "About" },
   { href: "#skills", label: "Skills" },
   { href: "#experience", label: "Experience" },
   { href: "#projects", label: "Projects" },
 ];
 
+// Brand mark component with sacred geometry hexagon
+const BrandMark = () => (
+  <div className="brand-mark">
+    <svg className="brand-geometry" viewBox="0 0 40 40" aria-hidden="true">
+      <polygon
+        points="20,2 37,11 37,29 20,38 3,29 3,11"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+      />
+    </svg>
+    <span className="brand-initials">RA</span>
+  </div>
+);
+
 export default function Header() {
   const [activeSection, setActiveSection] = useState("home");
+  const [isScrolled, setIsScrolled] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = LINKS.map(link => link.href.replace('#', ''));
+      // Scroll state for header transformation
+      setIsScrolled(window.scrollY > 50);
+
+      // Active section detection
+      const sections = LINKS.map((link) => link.href.replace("#", ""));
 
       // Check sections from bottom to top to find the current one
       for (const sectionId of [...sections].reverse()) {
@@ -34,36 +55,74 @@ export default function Header() {
       }
     };
 
-    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener("scroll", handleScroll, { passive: true });
     handleScroll(); // Set initial state
 
-    return () => window.removeEventListener('scroll', handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const renderTabNavLinks = () => LINKS.map((link) => {
-    const sectionId = link.href.replace('#', '');
-    const isActive = activeSection === sectionId;
-
-    return (
-      <NavigationMenu.Item key={link.href} className="NavigationMenuItem">
-        <NavigationMenu.Link asChild active={isActive}>
-          <NextLink
-            href={link.href}
-            className={`NavigationMenuLink ${isActive ? 'NavigationMenuLink--active' : ''}`}
-          >
-            {link.label === "Home" ? <HomeIcon /> : link.label}
-          </NextLink>
-        </NavigationMenu.Link>
-      </NavigationMenu.Item>
-    );
-  });
+  // Animation config
+  const duration = prefersReducedMotion ? 0 : 0.5;
+  const itemDuration = prefersReducedMotion ? 0 : 0.4;
+  const staggerDelay = prefersReducedMotion ? 0 : 0.06;
+  const initialDelay = prefersReducedMotion ? 0 : 0.1;
 
   return (
-    <NavigationMenu.Root className="NavigationMenuRoot">
-      <NavigationMenu.List className="NavigationMenuList">
-        {renderTabNavLinks()}
-      </NavigationMenu.List>
-    </NavigationMenu.Root>
+    <motion.header
+      initial={{ opacity: 0, y: prefersReducedMotion ? 0 : -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration, ease: "easeOut" }}
+    >
+      <NavigationMenu.Root className="NavigationMenuRoot">
+        <NavigationMenu.List
+          className={`NavigationMenuList ${isScrolled ? "NavigationMenuList--scrolled" : ""}`}
+        >
+          {LINKS.map((link, index) => {
+            const sectionId = link.href.replace("#", "");
+            const isActive = activeSection === sectionId;
+
+            return (
+              <NavigationMenu.Item key={link.href} className="NavigationMenuItem">
+                <motion.div
+                  className="NavigationMenuItemWrapper"
+                  initial={{ opacity: 0, y: prefersReducedMotion ? 0 : -10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: itemDuration,
+                    ease: "easeOut",
+                    delay: initialDelay + index * staggerDelay,
+                  }}
+                >
+                  <NavigationMenu.Link asChild active={isActive}>
+                    <NextLink
+                      href={link.href}
+                      className={`NavigationMenuLink ${isActive ? "NavigationMenuLink--active" : ""}`}
+                    >
+                      {/* Sliding active indicator */}
+                      {isActive && (
+                        <motion.div
+                          layoutId="activeIndicator"
+                          className="active-indicator"
+                          transition={{
+                            type: "spring",
+                            stiffness: 380,
+                            damping: 30,
+                          }}
+                        />
+                      )}
+
+                      {/* Content */}
+                      <span className="NavigationMenuLinkContent">
+                        {link.isBrand ? <BrandMark /> : link.label}
+                      </span>
+                    </NextLink>
+                  </NavigationMenu.Link>
+                </motion.div>
+              </NavigationMenu.Item>
+            );
+          })}
+        </NavigationMenu.List>
+      </NavigationMenu.Root>
+    </motion.header>
   );
 }
-

--- a/app/components/Header/style.css
+++ b/app/components/Header/style.css
@@ -7,351 +7,522 @@
 /* reset */
 button,
 p {
-	all: unset;
+  all: unset;
 }
 
+/* === Header Wrapper (overlay, doesn't push content down) === */
+header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: transparent;
+  pointer-events: none;
+  height: 0;
+  overflow: visible;
+}
+
+header > * {
+  pointer-events: auto;
+}
+
+/* === Navigation Root with Ambient Glow === */
 .NavigationMenuRoot {
-	display: flex;
-	position: sticky;
-	top: 8px;
-	left: 0;
-	right: 0;
-	justify-content: center;
-	height: 60px;
-	z-index: 50;
+  display: flex;
+  position: relative;
+  padding-top: 8px;
+  left: 0;
+  right: 0;
+  justify-content: center;
+  height: 60px;
 }
 
+/* Ambient glow behind header */
+.NavigationMenuRoot::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60%;
+  height: 100%;
+  background: radial-gradient(
+    ellipse at center,
+    var(--sg-primary-glow, rgba(74, 158, 255, 0.4)) 0%,
+    transparent 70%
+  );
+  opacity: 0.12;
+  pointer-events: none;
+  filter: blur(20px);
+}
+
+/* === Enhanced Glassmorphic Navigation List === */
 .NavigationMenuList {
-	display: flex;
-	justify-content: center;
-	background: rgba(15, 20, 30, 0.85);
-	backdrop-filter: blur(12px);
-	-webkit-backdrop-filter: blur(12px);
-	padding: 6px 8px;
-	border-radius: 999px;
-	list-style: none;
-	border: 1px solid rgba(100, 150, 255, 0.15);
-	box-shadow:
-		0 4px 24px rgba(0, 0, 0, 0.4),
-		inset 0 1px 0 rgba(255, 255, 255, 0.05);
-	margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(15, 20, 30, 0.75);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  padding: 6px 10px;
+  border-radius: 999px;
+  list-style: none;
+  border: 1px solid rgba(100, 150, 255, 0.12);
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 1px 3px rgba(0, 0, 0, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+  margin: 0;
+  transition: all 0.2s ease-out;
 }
 
+/* === Scroll Transformation === */
+.NavigationMenuList--scrolled {
+  background: rgba(15, 20, 30, 0.92);
+  backdrop-filter: blur(16px) saturate(200%);
+  -webkit-backdrop-filter: blur(16px) saturate(200%);
+  padding: 5px 8px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 0 1px rgba(100, 150, 255, 0.12);
+}
+
+/* === Navigation Item Wrapper === */
+.NavigationMenuItemWrapper {
+  position: relative;
+}
+
+/* === Navigation Link Base === */
 .NavigationMenuTrigger,
 .NavigationMenuLink {
-	padding: 10px 16px;
-	outline: none;
-	user-select: none;
-	font-family: var(--font-display);
-	font-weight: 500;
-	line-height: 1;
-	border-radius: 999px;
-	font-size: 14px;
-	color: rgba(255, 255, 255, 0.7);
-	transition: all 0.2s ease;
+  position: relative;
+  padding: 10px 16px;
+  outline: none;
+  user-select: none;
+  font-family: var(--font-display);
+  font-weight: 500;
+  line-height: 1;
+  border-radius: 999px;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+  transition: all 0.2s ease;
+  z-index: 1;
 }
 
-.NavigationMenuTrigger:focus,
-.NavigationMenuLink:focus {
-	box-shadow: 0 0 0 2px rgba(100, 150, 255, 0.4);
+.NavigationMenuLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 1;
 }
 
+.NavigationMenuLinkContent {
+  position: relative;
+  z-index: 1;
+}
+
+/* === Enhanced Focus States === */
+.NavigationMenuTrigger:focus-visible,
+.NavigationMenuLink:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--sg-void, #0a0c10),
+    0 0 0 4px var(--sg-primary, #4a9eff);
+}
+
+/* === Enhanced Hover States === */
 .NavigationMenuTrigger:hover,
 .NavigationMenuLink:hover {
-	background: rgba(100, 150, 255, 0.15);
-	color: rgba(255, 255, 255, 1);
+  color: var(--sg-text-primary, rgba(255, 255, 255, 0.92));
 }
 
-/* Active section highlight - gold accent */
+.NavigationMenuLink:hover:not(.NavigationMenuLink--active) {
+  background: rgba(100, 150, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+/* === Sliding Active Indicator === */
+.active-indicator {
+  position: absolute;
+  inset: 0;
+  background: rgba(212, 184, 114, 0.12);
+  border-radius: 999px;
+  border: 1px solid rgba(212, 184, 114, 0.2);
+  box-shadow:
+    0 0 16px rgba(212, 184, 114, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  z-index: 0;
+}
+
+/* === Active Link Styles === */
 .NavigationMenuLink--active {
-	background: rgba(201, 169, 98, 0.2);
-	color: var(--sg-secondary, #c9a962);
+  color: var(--sg-secondary, #d4b872);
+  background: transparent;
 }
 
 .NavigationMenuLink--active:hover {
-	background: rgba(201, 169, 98, 0.3);
-	color: var(--sg-secondary, #c9a962);
+  background: transparent;
+  color: var(--sg-secondary, #d4b872);
 }
 
+/* === Brand Mark === */
+.brand-mark {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.brand-geometry {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  color: var(--sg-secondary, #d4b872);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.NavigationMenuLink:hover .brand-geometry,
+.NavigationMenuLink--active .brand-geometry {
+  opacity: 0.6;
+}
+
+.brand-initials {
+  font-family: var(--font-mystical, "Cinzel", serif);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  color: var(--sg-text-primary, rgba(255, 255, 255, 0.92));
+  z-index: 1;
+  transition: color 0.2s ease;
+}
+
+.NavigationMenuLink--active .brand-initials {
+  color: var(--sg-secondary, #d4b872);
+}
+
+/* === Navigation Trigger === */
 .NavigationMenuTrigger {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2px;
 }
 
-.NavigationMenuLink {
-	display: block;
-	text-decoration: none;
-	font-size: 14px;
-	line-height: 1;
-}
-
+/* === Navigation Content === */
 .NavigationMenuContent {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	animation-duration: 250ms;
-	animation-timing-function: ease;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  animation-duration: 250ms;
+  animation-timing-function: ease;
 }
+
 .NavigationMenuContent[data-motion="from-start"] {
-	animation-name: enterFromLeft;
+  animation-name: enterFromLeft;
 }
+
 .NavigationMenuContent[data-motion="from-end"] {
-	animation-name: enterFromRight;
+  animation-name: enterFromRight;
 }
+
 .NavigationMenuContent[data-motion="to-start"] {
-	animation-name: exitToLeft;
+  animation-name: exitToLeft;
 }
+
 .NavigationMenuContent[data-motion="to-end"] {
-	animation-name: exitToRight;
-}
-@media only screen and (min-width: 600px) {
-	.NavigationMenuContent {
-		width: auto;
-	}
+  animation-name: exitToRight;
 }
 
+@media only screen and (min-width: 600px) {
+  .NavigationMenuContent {
+    width: auto;
+  }
+}
+
+/* === Navigation Indicator === */
 .NavigationMenuIndicator {
-	display: flex;
-	align-items: flex-end;
-	justify-content: center;
-	height: 10px;
-	top: 100%;
-	overflow: hidden;
-	z-index: 1;
-	transition:
-		width,
-		transform 250ms ease;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  height: 10px;
+  top: 100%;
+  overflow: hidden;
+  z-index: 1;
+  transition:
+    width,
+    transform 250ms ease;
 }
+
 .NavigationMenuIndicator[data-state="visible"] {
-	animation: fadeIn 200ms ease;
+  animation: fadeIn 200ms ease;
 }
+
 .NavigationMenuIndicator[data-state="hidden"] {
-	animation: fadeOut 200ms ease;
+  animation: fadeOut 200ms ease;
 }
 
+/* === Navigation Viewport === */
 .NavigationMenuViewport {
-	position: relative;
-	transform-origin: top center;
-	margin-top: 10px;
-	width: 100%;
-	background-color: white;
-	border-radius: 6px;
-	overflow: hidden;
-	box-shadow:
-		hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-		hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-	height: var(--radix-navigation-menu-viewport-height);
-	transition:
-		width,
-		height,
-		300ms ease;
+  position: relative;
+  transform-origin: top center;
+  margin-top: 10px;
+  width: 100%;
+  background-color: white;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow:
+    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+    hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+  height: var(--radix-navigation-menu-viewport-height);
+  transition:
+    width,
+    height,
+    300ms ease;
 }
+
 .NavigationMenuViewport[data-state="open"] {
-	animation: scaleIn 200ms ease;
+  animation: scaleIn 200ms ease;
 }
+
 .NavigationMenuViewport[data-state="closed"] {
-	animation: scaleOut 200ms ease;
-}
-@media only screen and (min-width: 600px) {
-	.NavigationMenuViewport {
-		width: var(--radix-navigation-menu-viewport-width);
-	}
+  animation: scaleOut 200ms ease;
 }
 
+@media only screen and (min-width: 600px) {
+  .NavigationMenuViewport {
+    width: var(--radix-navigation-menu-viewport-width);
+  }
+}
+
+/* === List Styles === */
 .List {
-	display: grid;
-	padding: 22px;
-	margin: 0;
-	column-gap: 10px;
-	list-style: none;
-}
-@media only screen and (min-width: 600px) {
-	.List.one {
-		width: 500px;
-		grid-template-columns: 0.75fr 1fr;
-	}
-	.List.two {
-		width: 600px;
-		grid-auto-flow: column;
-		grid-template-rows: repeat(3, 1fr);
-	}
+  display: grid;
+  padding: 22px;
+  margin: 0;
+  column-gap: 10px;
+  list-style: none;
 }
 
+@media only screen and (min-width: 600px) {
+  .List.one {
+    width: 500px;
+    grid-template-columns: 0.75fr 1fr;
+  }
+
+  .List.two {
+    width: 600px;
+    grid-auto-flow: column;
+    grid-template-rows: repeat(3, 1fr);
+  }
+}
+
+/* === List Item Styles === */
 .ListItemLink {
-	display: block;
-	outline: none;
-	text-decoration: none;
-	user-select: none;
-	padding: 12px;
-	border-radius: 6px;
-	font-size: 15px;
-	line-height: 1;
+  display: block;
+  outline: none;
+  text-decoration: none;
+  user-select: none;
+  padding: 12px;
+  border-radius: 6px;
+  font-size: 15px;
+  line-height: 1;
 }
+
 .ListItemLink:focus {
-	box-shadow: 0 0 0 2px var(--violet-7);
+  box-shadow: 0 0 0 2px var(--violet-7);
 }
+
 .ListItemLink:hover {
-	background-color: var(--mauve-3);
+  background-color: var(--mauve-3);
 }
 
 .ListItemHeading {
-	font-weight: 500;
-	line-height: 1.2;
-	margin-bottom: 5px;
-	color: var(--violet-12);
+  font-weight: 500;
+  line-height: 1.2;
+  margin-bottom: 5px;
+  color: var(--violet-12);
 }
 
 .ListItemText {
-	color: var(--mauve-11);
-	line-height: 1.4;
-	font-weight: initial;
+  color: var(--mauve-11);
+  line-height: 1.4;
+  font-weight: initial;
 }
 
+/* === Callout Styles === */
 .Callout {
-	display: flex;
-	justify-content: flex-end;
-	flex-direction: column;
-	width: 100%;
-	height: 100%;
-	background: linear-gradient(135deg, var(--purple-9) 0%, var(--indigo-9) 100%);
-	border-radius: 6px;
-	padding: 25px;
-	text-decoration: none;
-	outline: none;
-	user-select: none;
+  display: flex;
+  justify-content: flex-end;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, var(--purple-9) 0%, var(--indigo-9) 100%);
+  border-radius: 6px;
+  padding: 25px;
+  text-decoration: none;
+  outline: none;
+  user-select: none;
 }
+
 .Callout:focus {
-	box-shadow: 0 0 0 2px var(--violet-7);
+  box-shadow: 0 0 0 2px var(--violet-7);
 }
 
 .CalloutHeading {
-	color: white;
-	font-size: 18px;
-	font-weight: 500;
-	line-height: 1.2;
-	margin-top: 16px;
-	margin-bottom: 7px;
+  color: white;
+  font-size: 18px;
+  font-weight: 500;
+  line-height: 1.2;
+  margin-top: 16px;
+  margin-bottom: 7px;
 }
 
 .CalloutText {
-	color: var(--mauve-4);
-	font-size: 14px;
-	line-height: 1.3;
+  color: var(--mauve-4);
+  font-size: 14px;
+  line-height: 1.3;
 }
 
+/* === Viewport Position === */
 .ViewportPosition {
-	position: absolute;
-	display: flex;
-	justify-content: center;
-	width: 100%;
-	top: 100%;
-	left: 0;
-	perspective: 2000px;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  top: 100%;
+  left: 0;
+  perspective: 2000px;
 }
 
+/* === Caret Styles === */
 .CaretDown {
-	position: relative;
-	color: var(--violet-10);
-	top: 1px;
-	transition: transform 250ms ease;
+  position: relative;
+  color: var(--violet-10);
+  top: 1px;
+  transition: transform 250ms ease;
 }
+
 [data-state="open"] > .CaretDown {
-	transform: rotate(-180deg);
+  transform: rotate(-180deg);
 }
 
+/* === Arrow Styles === */
 .Arrow {
-	position: relative;
-	top: 70%;
-	background-color: white;
-	width: 10px;
-	height: 10px;
-	transform: rotate(45deg);
-	border-top-left-radius: 2px;
+  position: relative;
+  top: 70%;
+  background-color: white;
+  width: 10px;
+  height: 10px;
+  transform: rotate(45deg);
+  border-top-left-radius: 2px;
 }
 
+/* === Keyframe Animations === */
 @keyframes enterFromRight {
-	from {
-		opacity: 0;
-		transform: translateX(200px);
-	}
-	to {
-		opacity: 1;
-		transform: translateX(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateX(200px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 @keyframes enterFromLeft {
-	from {
-		opacity: 0;
-		transform: translateX(-200px);
-	}
-	to {
-		opacity: 1;
-		transform: translateX(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateX(-200px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 @keyframes exitToRight {
-	from {
-		opacity: 1;
-		transform: translateX(0);
-	}
-	to {
-		opacity: 0;
-		transform: translateX(200px);
-	}
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(200px);
+  }
 }
 
 @keyframes exitToLeft {
-	from {
-		opacity: 1;
-		transform: translateX(0);
-	}
-	to {
-		opacity: 0;
-		transform: translateX(-200px);
-	}
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-200px);
+  }
 }
 
 @keyframes scaleIn {
-	from {
-		opacity: 0;
-		transform: rotateX(-30deg) scale(0.9);
-	}
-	to {
-		opacity: 1;
-		transform: rotateX(0deg) scale(1);
-	}
+  from {
+    opacity: 0;
+    transform: rotateX(-30deg) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: rotateX(0deg) scale(1);
+  }
 }
 
 @keyframes scaleOut {
-	from {
-		opacity: 1;
-		transform: rotateX(0deg) scale(1);
-	}
-	to {
-		opacity: 0;
-		transform: rotateX(-10deg) scale(0.95);
-	}
+  from {
+    opacity: 1;
+    transform: rotateX(0deg) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: rotateX(-10deg) scale(0.95);
+  }
 }
 
 @keyframes fadeIn {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fadeOut {
-	from {
-		opacity: 1;
-	}
-	to {
-		opacity: 0;
-	}
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+/* === Reduced Motion === */
+@media (prefers-reduced-motion: reduce) {
+  .NavigationMenuList,
+  .NavigationMenuLink,
+  .brand-geometry,
+  .brand-initials,
+  .active-indicator {
+    transition: none;
+  }
+
+  .NavigationMenuContent,
+  .NavigationMenuIndicator,
+  .NavigationMenuViewport {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary

- Add "RA" brand mark with sacred geometry hexagon outline replacing generic Home icon
- Implement staggered entry animation on page load using motion/react
- Add sliding active indicator with spring physics (`layoutId`)
- Add scroll transformation (header becomes more opaque/compact after 50px scroll)
- Enhance glassmorphism with deeper blur, saturate filter, and ambient glow
- Add reduced motion support via `useReducedMotion` hook
- Improve focus-visible states for accessibility

## Test plan

- [ ] Verify header animates in on page load with staggered nav items
- [ ] Verify "RA" brand mark shows hexagon on hover/active
- [ ] Verify active indicator slides smoothly between nav items when scrolling
- [ ] Verify header becomes more opaque when scrolled past 50px
- [ ] Verify no black bar appears at top of page on load
- [ ] Verify header remains sticky when scrolling
- [ ] Test with `prefers-reduced-motion` enabled (animations should be disabled)

Closes SG-132

🤖 Generated with [Claude Code](https://claude.com/claude-code)