### PR TITLE
feat(header): add subpage variant for art gallery navigation

### DIFF
--- a/app/art/page.tsx
+++ b/app/art/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { Container } from "@radix-ui/themes";
+import Header from "@/app/components/Header";
 import { IMAGES, getToolCounts } from "./images";
 import { CosmicBackground } from "./components/CosmicBackground";
 import { FilterBar } from "./components/FilterBar";
@@ -21,6 +22,7 @@ export default function ArtPage() {
 
   return (
     <div className="gallery-page">
+      <Header variant="subpage" />
       <CosmicBackground />
       <GalleryHero />
 

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -6,13 +6,21 @@ import { useEffect, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import "./style.css";
 
-const LINKS = [
+type HeaderVariant = "home" | "subpage";
+
+interface HeaderProps {
+  variant?: HeaderVariant;
+}
+
+const HOME_LINKS = [
   { href: "#home", label: "Home", isBrand: true },
   { href: "#about", label: "About" },
   { href: "#skills", label: "Skills" },
   { href: "#experience", label: "Experience" },
   { href: "#projects", label: "Projects" },
 ];
+
+const SUBPAGE_LINKS = [{ href: "/", label: "Home", isBrand: true }];
 
 // Brand mark component with sacred geometry hexagon
 const BrandMark = () => (
@@ -29,12 +37,18 @@ const BrandMark = () => (
   </div>
 );
 
-export default function Header() {
+export default function Header({ variant = "home" }: HeaderProps) {
   const [activeSection, setActiveSection] = useState("home");
   const [isScrolled, setIsScrolled] = useState(false);
   const prefersReducedMotion = useReducedMotion();
 
+  const isSubpage = variant === "subpage";
+  const LINKS = isSubpage ? SUBPAGE_LINKS : HOME_LINKS;
+
   useEffect(() => {
+    // Skip scroll tracking for subpage variant
+    if (isSubpage) return;
+
     const handleScroll = () => {
       // Scroll state for header transformation
       setIsScrolled(window.scrollY > 50);
@@ -59,7 +73,7 @@ export default function Header() {
     handleScroll(); // Set initial state
 
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [isSubpage]);
 
   // Animation config
   const duration = prefersReducedMotion ? 0 : 0.5;
@@ -75,11 +89,12 @@ export default function Header() {
     >
       <NavigationMenu.Root className="NavigationMenuRoot">
         <NavigationMenu.List
-          className={`NavigationMenuList ${isScrolled ? "NavigationMenuList--scrolled" : ""}`}
+          className={`NavigationMenuList ${isScrolled ? "NavigationMenuList--scrolled" : ""} ${isSubpage ? "NavigationMenuList--subpage" : ""}`}
         >
           {LINKS.map((link, index) => {
-            const sectionId = link.href.replace("#", "");
-            const isActive = activeSection === sectionId;
+            const sectionId = link.href.replace("#", "").replace("/", "home");
+            // On subpage, brand is always active; on home, use scroll-based detection
+            const isActive = isSubpage ? link.isBrand : activeSection === sectionId;
 
             return (
               <NavigationMenu.Item key={link.href} className="NavigationMenuItem">

--- a/app/components/Header/style.css
+++ b/app/components/Header/style.css
@@ -88,6 +88,29 @@ header > * {
     0 0 0 1px rgba(100, 150, 255, 0.12);
 }
 
+/* === Subpage Variant === */
+.NavigationMenuRoot:has(.NavigationMenuList--subpage) {
+  justify-content: flex-start;
+  padding-left: 24px;
+}
+
+.NavigationMenuList--subpage {
+  padding: 6px 8px;
+}
+
+.NavigationMenuList--subpage .NavigationMenuLink {
+  padding: 8px 12px;
+}
+
+.NavigationMenuList--subpage .brand-mark {
+  width: 28px;
+  height: 28px;
+}
+
+.NavigationMenuList--subpage .brand-initials {
+  font-size: 12px;
+}
+
 /* === Navigation Item Wrapper === */
 .NavigationMenuItemWrapper {
   position: relative;


### PR DESCRIPTION
## Summary
- Add `variant` prop to Header component (`'home'` | `'subpage'`)
- Subpage variant shows only BrandMark in top-left corner, linking to `/`
- Add Header to `/art` gallery page for navigation back to main portfolio

## Test plan
- [ ] Visit `/art` page - BrandMark appears in top-left
- [ ] Scroll down - Header stays sticky, doesn't overlap filter bar
- [ ] Click BrandMark - Navigates to home page
- [ ] Homepage header unchanged (centered, full navigation)

Closes SG-133

🤖 Generated with [Claude Code](https://claude.com/claude-code)