### PR TITLE
feat(projects): move badge and title into gradient header with featured support

### DIFF
--- a/app/components/Projects.css
+++ b/app/components/Projects.css
@@ -53,13 +53,57 @@
     radial-gradient(circle at 80% 70%, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
     radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.02) 2px, transparent 2px);
   background-size: 40px 40px, 60px 60px, 80px 80px;
+  z-index: 1;
 }
 
-/* Hover effect */
-.project-card:hover .project-visual {
-  background-position: 100% 100%;
+/* Bottom gradient scrim for text readability */
+.project-visual::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80%;
+  background: linear-gradient(
+    to top,
+    rgba(10, 12, 16, 0.85) 0%,
+    rgba(10, 12, 16, 0.6) 40%,
+    rgba(10, 12, 16, 0.2) 70%,
+    transparent 100%
+  );
+  z-index: 1;
+  pointer-events: none;
 }
 
+/* Header content container - positions badge and title at bottom */
+.project-visual-content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 2;
+}
+
+/* Title styling for readability */
+.project-visual-title {
+  color: var(--sg-text-primary);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  margin: 0;
+  line-height: 1.2;
+}
+
+/* Badge positioning adjustment within header */
+.project-visual-content .sg-badge--featured {
+  align-self: flex-start;
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+}
+
+/* Hover effect - subtle highlight overlay */
 .project-card:hover .project-visual::after {
   content: '';
   position: absolute;
@@ -69,4 +113,5 @@
     rgba(255, 255, 255, 0.02) 0%,
     transparent 100%
   );
+  pointer-events: none;
 }

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -16,7 +16,8 @@ const PROJECTS = [
     tech: [
       "Nextjs", "radix-ui", "TypeScript", "MDX", "Jest", "Vitest"
     ],
-    gradientType: "blue"
+    gradientType: "blue",
+    featured: true
   },
   {
     title: "AI Art Gallery",
@@ -82,16 +83,18 @@ export default function Projects() {
             size="3"
             mx="4"
             mb="8"
-            className="sg-card project-card"
+            className={`sg-card project-card ${proj.featured ? 'sg-card--featured' : ''}`}
           >
             <Box className={`project-visual project-visual--${proj.gradientType}`}>
               <Box className="project-visual-pattern" />
+              <Box className="project-visual-content">
+                <Badge size="1" className="sg-badge--featured">
+                  {proj.category}
+                </Badge>
+                <Heading size="6" className="project-visual-title">{proj.title}</Heading>
+              </Box>
             </Box>
             <Box p="4">
-              <Badge size="1" mb="2" className="sg-badge--featured">
-                {proj.category}
-              </Badge>
-              <Heading mb="4" size="4">{proj.title}</Heading>
             {proj.callout && (
               <Callout.Root mb="4">
                 <Callout.Icon>


### PR DESCRIPTION
## Summary
- Move project type badge and title into the colored gradient header area for stronger visual impact
- Add featured project styling to Sacred Geometry Webapp to highlight best work for recruiters
- Increase title font size for bolder presentation

## Changes
- **Header content positioning**: Badge and title now live inside the gradient header, anchored to the bottom
- **Text readability**: Added gradient scrim overlay + text-shadow for contrast against subtle gradients
- **Featured project support**: Sacred Geometry Webapp marked as featured with gold accent styling
- **Title size increase**: Bumped from size 4 → 6 for more commanding presence
- **Browser fixes**: Added Safari `-webkit-backdrop-filter` prefix, fixed hover overlay pointer-events

## Files Modified
- `app/components/Projects.tsx` - JSX structure + featured flag
- `app/components/Projects.css` - Header content styling, scrim, text effects

## Test plan
- [x] Verify text readable on all gradient types (blue, gold, purple, green)
- [x] Verify featured card has gold accent styling
- [x] Verify hover effects work correctly
- [x] Build passes

Closes SG-134

🤖 Generated with [Claude Code](https://claude.com/claude-code)