### PR TITLE
feat(ui): implement refined luxury portfolio redesign

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -11,34 +11,47 @@ const KEY_STRENGTHS = [
 
 export default function About() {
   return (
-    <Box id="about" py="8" style={{ background: "var(--sg-gradient-section)", position: "relative", overflow: "hidden" }}>
+    <Box id="about" py="9" style={{ background: "var(--sg-gradient-section)", position: "relative", overflow: "hidden" }}>
       <GeometricPattern variant="dots" opacity={0.02} />
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
-        <Flex direction="column" justify="center" align="center">
-          <Heading mb="4" size="8" className="section-title">About</Heading>
-          <Container p="6" mx="4" my="8" size="3" className="sg-card">
-            {/* Lead statement with gold accent */}
-            <Text size="5" weight="medium" mb="4" style={{ color: "var(--sg-secondary)", display: "block" }}>
-              15 years crafting performant, user-centered web applications.
-            </Text>
+        <Container size="4" px="6">
+          {/* Asymmetric grid layout */}
+          <Flex direction={{ initial: "column", md: "row" }} gap="8" align="start">
+            {/* Left column - Section header */}
+            <Box style={{ flex: "0 0 200px" }}>
+              <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
+                Background
+              </Text>
+              <Heading size="8" className="section-title" style={{ textAlign: "left" }}>
+                About
+              </Heading>
+            </Box>
 
-            {/* Key competency badges */}
-            <Flex gap="2" wrap="wrap" mb="4">
-              {KEY_STRENGTHS.map((strength) => (
-                <Badge key={strength} size="2" className="sg-badge--featured">
-                  {strength}
-                </Badge>
-              ))}
-            </Flex>
+            {/* Right column - Content */}
+            <Box style={{ flex: 1 }}>
+              {/* Oversized lead statement */}
+              <Text className="lead-statement" mb="6" style={{ display: "block" }}>
+                15 years crafting performant, user-centered web applications that drive measurable business outcomes.
+              </Text>
 
-            {/* Expanded description */}
-            <Text size="4">
-              Specializing in B2B and B2C domains within agile teams. Expert at translating
-              complex technical requirements into scalable UI systems—seeking frontend roles
-              where thoughtful code meets innovation.
-            </Text>
-          </Container>
-        </Flex>
+              {/* Key competency badges */}
+              <Flex gap="2" wrap="wrap" mb="6">
+                {KEY_STRENGTHS.map((strength) => (
+                  <Badge key={strength} size="2" className="sg-badge--featured">
+                    {strength}
+                  </Badge>
+                ))}
+              </Flex>
+
+              {/* Expanded description */}
+              <Text size="4" style={{ color: "var(--sg-text-secondary)", lineHeight: 1.8 }}>
+                Specializing in B2B and B2C domains within agile teams. Expert at translating
+                complex technical requirements into scalable UI systems—seeking frontend roles
+                where thoughtful code meets innovation.
+              </Text>
+            </Box>
+          </Flex>
+        </Container>
       </AnimatedSection>
     </Box>
   )

--- a/app/components/Experience/components/ExperienceItem/index.tsx
+++ b/app/components/Experience/components/ExperienceItem/index.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Box, Button, Container, Flex, Heading, Text } from "@radix-ui/themes";
+import { Box, Button, Flex, Heading, Text } from "@radix-ui/themes";
 import { RowSpacingIcon, Cross2Icon } from "@radix-ui/react-icons";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import React from "react";
-import "./style.css";
 
 const { useState } = React;
 
@@ -16,16 +15,17 @@ type ExperienceItemType = {
   description: string;
   highlights: string[];
   featured?: boolean;
+  position?: "left" | "right";
 }
 
-export default function Experience({
+export default function ExperienceItem({
   title,
   company,
   companyLink,
   period,
   description,
   highlights,
-  featured = false
+  featured = false,
 }: ExperienceItemType) {
   const [isOpen, setIsOpen] = useState(featured);
 
@@ -35,33 +35,81 @@ export default function Experience({
       open={isOpen}
       onOpenChange={setIsOpen}
     >
-      <Container p="4" mx="4" my="8" size="3" className={`sg-card ${featured ? 'sg-card--featured' : ''}`}>
-        <Heading size="6">{title}</Heading>
-        <Flex direction="row" justify="between" my="2" align="center">
-          <Text>
-            <a href={companyLink} target="_blank" rel="noopener noreferrer" style={{ color: "var(--sg-primary)" }}>{company}</a>
-          </Text>
-          <Text className="date-badge">{period}</Text>
+      <Box p="5" mb="6" className={`sg-card ${featured ? 'sg-card--featured' : ''}`}>
+        <Flex direction="row" justify="between" align="start" mb="2" gap="4">
+          <Heading size="5" style={{ color: featured ? "var(--sg-secondary)" : "var(--sg-text-primary)" }}>
+            {title}
+          </Heading>
+          <Text className="date-badge" style={{ whiteSpace: "nowrap" }}>{period}</Text>
         </Flex>
-        <Text>{description}</Text>
-        <Box mb="4">
+        <Text size="3" mb="3" style={{ display: "block" }}>
+          <a
+            href={companyLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: "var(--sg-primary)", textDecoration: "none" }}
+          >
+            {company}
+          </a>
+        </Text>
+        <Text size="3" style={{ color: "var(--sg-text-secondary)", display: "block" }} mb="3">
+          {description}
+        </Text>
+        <Box>
           <Collapsible.Content>
-            <ul>
+            <ul
+              style={{
+                listStyle: "none",
+                margin: 0,
+                paddingLeft: "1rem",
+              }}
+            >
               {highlights.map((highlight, highlightIndex) => (
-                <li key={highlightIndex}>{highlight}</li>
+                <li
+                  key={highlightIndex}
+                  style={{
+                    position: "relative",
+                    paddingLeft: "1rem",
+                    marginBottom: "0.5rem",
+                    color: "var(--sg-text-secondary)",
+                    fontSize: "0.9rem",
+                    lineHeight: 1.6
+                  }}
+                >
+                  <span
+                    style={{
+                      position: "absolute",
+                      left: 0,
+                      top: "0.5em",
+                      width: "4px",
+                      height: "4px",
+                      borderRadius: "50%",
+                      background: "var(--sg-gold)",
+                      display: "block"
+                    }}
+                  />
+                  {highlight}
+                </li>
               ))}
             </ul>
           </Collapsible.Content>
         </Box>
-        <Box>
+        <Box mt="3">
           <Collapsible.Trigger asChild>
-            <Button className="IconButton">
+            <Button
+              variant="ghost"
+              size="1"
+              style={{
+                color: "var(--sg-secondary)",
+                cursor: "pointer"
+              }}
+            >
               {isOpen ? <Cross2Icon /> : <RowSpacingIcon />}
-              {isOpen ? "Read Less" : "Read More"}
+              <Text ml="1">{isOpen ? "Less" : "More"}</Text>
             </Button>
           </Collapsible.Trigger>
         </Box>
-      </Container>
+      </Box>
     </Collapsible.Root>
   )
 }

--- a/app/components/Experience/index.tsx
+++ b/app/components/Experience/index.tsx
@@ -1,7 +1,8 @@
-import { Box, Flex, Heading } from "@radix-ui/themes";
+import { Box, Container, Flex, Heading, Text } from "@radix-ui/themes";
 import ExperienceItem from "./components/ExperienceItem";
 import GeometricPattern from "../GeometricPattern";
 import AnimatedSection from "../AnimatedSection";
+import "./style.css";
 
 const EXPERIENCE = [
   {
@@ -54,8 +55,8 @@ const EXPERIENCE = [
     description: "SAVO (B2B) was an industry leader in the sales enablement space, providing SaaS software used by some of the largest companies in the world (Disney, American Express, Google, UPS, etc.). I worked within Agile and Lean UX methodologies taking projects from discovery to implementation.",
     highlights: [
       "Led the spinout of an autonomous UI/UX team that adopted a user-centered process, conducting 50+ User Research sessions, Usability Interviews, and Design Workshops, resulting in a 30% increase in user satisfaction.",
-			"Architected and implemented UI features that embedded SAVO’s sales content and enablement tools directly within Salesforce, creating a seamless experience for enterprise sales teams and reducing context-switching between platforms.",
-			"Developed UI components and features that integrated SAVO’s sales enablement platform into Salesforce, enabling sales teams to access content, training, and playbooks within their existing CRM workflow, improving adoption rates and user engagement.",
+			"Architected and implemented UI features that embedded SAVO's sales content and enablement tools directly within Salesforce, creating a seamless experience for enterprise sales teams and reducing context-switching between platforms.",
+			"Developed UI components and features that integrated SAVO's sales enablement platform into Salesforce, enabling sales teams to access content, training, and playbooks within their existing CRM workflow, improving adoption rates and user engagement.",
       "Contributed to the production of a holistic Design Language and Living Design System using Ember.js and Material Design, used within our own products and integrated with Salesforce, resulting in a 20% improvement in developer productivity.",
       "Established the SAVO Front-End Guild, a bi-weekly meeting for all developers that covered Front-end development basics, best practices, and industry trends.",
 			"Authored design system documentation and contribution guidelines to ensure consistency across multiple product teams."
@@ -78,33 +79,43 @@ const EXPERIENCE = [
 export default function Experience() {
 
   return (
-    <Box id="experience" py="8" style={{ background: "var(--sg-gradient-section)", position: "relative", overflow: "hidden" }}>
+    <Box id="experience" py="9" style={{ background: "var(--sg-gradient-section)", position: "relative", overflow: "hidden" }}>
       <GeometricPattern variant="dots" opacity={0.02} />
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
-        <Flex direction="column" justify="center" align="center">
-          <Heading size="8" className="section-title">Experience</Heading>
-          <Box>
-            {EXPERIENCE.map(({
-              title,
-              company,
-              companyLink,
-              period,
-              description,
-              highlights,
-              featured
-             }, index) => (
-              <ExperienceItem
-                title={title}
-                company={company}
-                companyLink={companyLink}
-                period={period}
-                description={description}
-                highlights={highlights}
-                featured={featured}
-                key={index}
-              />
-            ))}
-          </Box>
+        <Flex direction="column" align="center">
+          {/* Centered section header */}
+          <Text className="section-subtitle" mb="2">
+            Career
+          </Text>
+          <Heading size="8" mb="8" className="section-title">
+            Experience
+          </Heading>
+
+          {/* Timeline */}
+          <Container size="3" px="4">
+            <Box className="experience-timeline">
+              {EXPERIENCE.map(({
+                title,
+                company,
+                companyLink,
+                period,
+                description,
+                highlights,
+                featured
+               }, index) => (
+                <ExperienceItem
+                  title={title}
+                  company={company}
+                  companyLink={companyLink}
+                  period={period}
+                  description={description}
+                  highlights={highlights}
+                  featured={featured}
+                  key={index}
+                />
+              ))}
+            </Box>
+          </Container>
         </Flex>
       </AnimatedSection>
     </Box>

--- a/app/components/Experience/style.css
+++ b/app/components/Experience/style.css
@@ -1,0 +1,85 @@
+/* Experience Timeline Styles */
+
+.experience-timeline {
+  position: relative;
+  padding-left: 2rem;
+}
+
+/* Vertical gold line */
+.experience-timeline::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    var(--sg-gold) 10%,
+    var(--sg-gold) 90%,
+    transparent 100%
+  );
+}
+
+/* Timeline dot at each item */
+.experience-timeline .sg-card {
+  position: relative;
+}
+
+.experience-timeline .sg-card::before {
+  content: '';
+  position: absolute;
+  left: -2.5rem;
+  top: 2rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--sg-void);
+  border: 2px solid var(--sg-gold);
+  z-index: 2;
+}
+
+/* Featured item has larger, filled dot */
+.experience-timeline .sg-card--featured::before {
+  width: 16px;
+  height: 16px;
+  left: calc(-2.5rem - 2px);
+  background: var(--sg-gold);
+  box-shadow: 0 0 12px var(--sg-gold-glow);
+}
+
+/* Connecting line from dot to card */
+.experience-timeline .sg-card::after {
+  content: '';
+  position: absolute;
+  left: -1.5rem;
+  top: calc(2rem + 5px);
+  width: 1.5rem;
+  height: 1px;
+  background: rgba(201, 169, 98, 0.3);
+}
+
+/* Mobile: simpler timeline */
+@media (max-width: 767px) {
+  .experience-timeline {
+    padding-left: 1.5rem;
+  }
+
+  .experience-timeline .sg-card::before {
+    left: -1.85rem;
+    width: 10px;
+    height: 10px;
+  }
+
+  .experience-timeline .sg-card--featured::before {
+    width: 12px;
+    height: 12px;
+    left: calc(-1.85rem - 1px);
+  }
+
+  .experience-timeline .sg-card::after {
+    left: -1rem;
+    width: 1rem;
+  }
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -12,17 +12,16 @@ export default function Footer() {
       asChild
       style={{
         background: "var(--sg-void)",
-        borderTop: "1px solid rgba(74, 158, 255, 0.1)",
+        borderTop: "1px solid rgba(201, 169, 98, 0.15)",
       }}
     >
       <footer>
         {/* Gold geometric divider */}
         <Box
           style={{
-            height: "1px",
+            height: "2px",
             background:
-              "linear-gradient(90deg, transparent, var(--sg-secondary), transparent)",
-            opacity: 0.5,
+              "linear-gradient(90deg, transparent 0%, var(--sg-gold-deep) 20%, var(--sg-gold) 50%, var(--sg-gold-deep) 80%, transparent 100%)",
           }}
         />
 

--- a/app/components/Hero.css
+++ b/app/components/Hero.css
@@ -1,34 +1,111 @@
-.Canvas,
-.Wrapper {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 1;
+/* Hero Section - Refined Luxury */
+.hero-section {
+  background: var(--blue-a9);
+  position: relative;
+  overflow: hidden;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
 }
 
-/* Hero cube container */
+/* Metatron's Cube - positioned behind portrait on desktop */
 .hero-cube-container {
+  position: absolute;
+  left: 10%;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 0;
+  opacity: 0.15;
+  pointer-events: none;
+}
+
+/* Diagonal gold accent line */
+.hero-diagonal-accent {
+  position: absolute;
+  width: 200%;
+  height: 1px;
+  background: linear-gradient(90deg, var(--sg-secondary), transparent);
+  transform: rotate(-12deg);
+  top: 70%;
+  left: -30%;
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+/* Content wrapper */
+.hero-content-wrapper {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding: 6rem 0;
+}
+
+/* Grid container */
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4rem;
+  align-items: center;
+}
+
+/* Portrait Column */
+.hero-portrait-column {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.hero-portrait-wrapper {
   position: relative;
 }
 
-/* Portrait in content flow */
-.hero-portrait {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 1rem;
+.hero-portrait-image {
+  width: 300px;
+  height: 300px;
+  border-radius: 50%;
+  border: 4px solid var(--sg-secondary);
+  box-shadow:
+    0 0 60px rgba(212, 184, 114, 0.4),
+    0 0 120px rgba(74, 158, 255, 0.2),
+    0 20px 60px rgba(0, 0, 0, 0.5);
+  object-fit: cover;
 }
 
-.hero-portrait-image {
-  border-radius: 50%;
-  border: 3px solid var(--sg-secondary);
-  box-shadow:
-    0 0 40px rgba(212, 184, 114, 0.3),
-    0 0 80px rgba(74, 158, 255, 0.2);
-  object-fit: cover;
+/* Content Column */
+.hero-content-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Stacked Name */
+.hero-name {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+}
+
+.hero-name-line {
+  display: block;
+  text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+/* Title */
+.hero-title {
+  color: var(--sg-text-primary);
+  font-family: var(--font-display);
+  font-weight: 400;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+}
+
+/* Tagline */
+.hero-tagline {
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+/* CTA Buttons */
+.hero-cta {
+  margin-top: 1rem;
 }
 
 /* Resume button styling */
@@ -40,15 +117,99 @@
 }
 
 .resume-button:hover {
-  background: rgba(212, 184, 114, 0.1) !important;
+  background: rgba(212, 184, 114, 0.15) !important;
   border-color: var(--sg-secondary) !important;
-  box-shadow: 0 0 20px rgba(212, 184, 114, 0.2);
+  box-shadow: 0 0 25px rgba(212, 184, 114, 0.25);
 }
 
-/* Mobile responsiveness */
-@media (max-width: 768px) {
+/* ===========================================
+   RESPONSIVE STYLES
+   =========================================== */
+
+/* Tablet landscape */
+@media (max-width: 1024px) {
+  .hero-grid {
+    gap: 3rem;
+  }
+
   .hero-portrait-image {
-    width: 120px !important;
-    height: 120px !important;
+    width: 260px;
+    height: 260px;
+  }
+
+  .hero-cube-container {
+    left: 5%;
+    opacity: 0.1;
+  }
+}
+
+/* Tablet portrait and below - stacked layout */
+@media (max-width: 768px) {
+  .hero-section {
+    min-height: auto;
+  }
+
+  .hero-content-wrapper {
+    padding: 4rem 0;
+  }
+
+  .hero-grid {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+    text-align: center;
+  }
+
+  /* Portrait on top for mobile */
+  .hero-portrait-column {
+    order: -1;
+  }
+
+  .hero-portrait-image {
+    width: 200px;
+    height: 200px;
+  }
+
+  .hero-content-column {
+    align-items: center;
+  }
+
+  .hero-name {
+    align-items: center;
+  }
+
+  .hero-cta {
+    justify-content: center;
+  }
+
+  .hero-cube-container {
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0.08;
+  }
+
+  .hero-diagonal-accent {
+    display: none;
+  }
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  .hero-content-wrapper {
+    padding: 3rem 0;
+  }
+
+  .hero-portrait-image {
+    width: 160px;
+    height: 160px;
+  }
+
+  .hero-cta {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-cta > * {
+    width: 100%;
+    justify-content: center;
   }
 }

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Box, Button, Container, Flex, Heading, IconButton, Link, Section, Text } from "@radix-ui/themes";
-import { DownloadIcon, EnvelopeClosedIcon, GitHubLogoIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
+import { Box, Button, Container, Flex, Section, Text } from "@radix-ui/themes";
+import { DownloadIcon } from "@radix-ui/react-icons";
 import { motion, useScroll, useTransform, useReducedMotion } from "motion/react";
 import { useRef } from "react";
 import Image from "next/image";
@@ -24,7 +24,7 @@ export default function Hero() {
     [0, prefersReducedMotion ? 0 : 150]
   );
 
-  const textY = useTransform(
+  const contentY = useTransform(
     scrollYProgress,
     [0, 1],
     [0, prefersReducedMotion ? 0 : 50]
@@ -40,69 +40,98 @@ export default function Hero() {
     <Section
       ref={sectionRef}
       id="home"
-      style={{ background: "var(--blue-a9)", position: "relative", overflow: "hidden" }}
+      className="hero-section"
     >
-      <Box py="9" style={{ position: "relative" }}>
-        <AmbientParticles />
+      <AmbientParticles />
 
-        <motion.div style={{ y: cubeY, opacity }} className="hero-cube-container">
-          <MetatronsCube />
-        </motion.div>
+      {/* Metatron's Cube - positioned behind portrait */}
+      <motion.div style={{ y: cubeY, opacity }} className="hero-cube-container">
+        <MetatronsCube />
+      </motion.div>
 
-        <motion.div style={{ y: textY, opacity, position: "relative", zIndex: 1 }}>
-          <Container py="8" size="3">
-            <Flex direction="column" gap="4" align="center">
-              <motion.div
-                className="hero-portrait"
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ delay: 0.3, duration: 0.6, ease: "easeOut" }}
-              >
+      {/* Diagonal gold accent line */}
+      <div className="hero-diagonal-accent" aria-hidden="true" />
+
+      <motion.div style={{ y: contentY, opacity }} className="hero-content-wrapper">
+        <Container size="4" className="hero-container">
+          <div className="hero-grid">
+            {/* Portrait Column */}
+            <motion.div
+              className="hero-portrait-column"
+              initial={{ opacity: 0, scale: 0.8, x: -30 }}
+              animate={{ opacity: 1, scale: 1, x: 0 }}
+              transition={{ delay: 0.3, duration: 0.8, ease: "easeOut" }}
+            >
+              <div className="hero-portrait-wrapper">
                 <Image
                   src="/profile.jpeg"
                   alt="Rob Abby - Staff Frontend Engineer"
-                  width={150}
-                  height={150}
+                  width={300}
+                  height={300}
                   priority
                   className="hero-portrait-image"
                 />
+              </div>
+            </motion.div>
+
+            {/* Content Column */}
+            <div className="hero-content-column">
+              {/* Stacked Name */}
+              <motion.div
+                className="hero-name-wrapper"
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.5, duration: 0.6, ease: "easeOut" }}
+              >
+                <h1 className="display-dramatic hero-name">
+                  <span className="hero-name-line">Rob</span>
+                  <span className="hero-name-line">Abby</span>
+                </h1>
               </motion.div>
-              <Heading mb="2" size="9" style={{ textShadow: "0 2px 4px rgba(0, 0, 0, 0.3)" }}>Rob Abby</Heading>
-              <Text size="7" style={{ color: "var(--sg-text-primary)", textShadow: "0 1px 3px rgba(0, 0, 0, 0.3)" }}>Staff Frontend Engineer</Text>
-              <Text size="3" mb="4" style={{ color: "var(--sg-secondary)", letterSpacing: "0.1em", fontFamily: "var(--font-display)", textShadow: "0 1px 2px rgba(0, 0, 0, 0.3)" }}>
-                15+ Years Building Web Experiences
-              </Text>
-              <Flex direction="row" gap="4" mb="4">
-                <Link href="https://www.linkedin.com/in/robabby/" target="_blank">
-                  <IconButton size="4" variant="ghost" style={{ cursor: "pointer" }}>
-                    <LinkedInLogoIcon width="24" height="24" />
-                  </IconButton>
-                </Link>
-                <Link href="https://github.com/robabby" target="_blank">
-                  <IconButton size="4" variant="ghost" style={{ cursor: "pointer" }}>
-                    <GitHubLogoIcon width="24" height="24" />
-                  </IconButton>
-                </Link>
-                <Link href="mailto:robabby23@gmail.com">
-                  <IconButton size="4" variant="ghost" style={{ cursor: "pointer" }}>
-                    <EnvelopeClosedIcon width="24" height="24" />
-                  </IconButton>
-                </Link>
-              </Flex>
-              <Flex direction="row" gap="3">
-                <Button size="3" asChild style={{ cursor: "pointer" }}>
-                  <a href="#experience">View Experience</a>
-                </Button>
-                <Button size="3" variant="outline" asChild className="resume-button">
-                  <a href="/robert-abby-resume.pdf" download>
-                    <DownloadIcon /> Resume
-                  </a>
-                </Button>
-              </Flex>
-            </Flex>
-          </Container>
-        </motion.div>
-      </Box>
+
+              {/* Title */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.7, duration: 0.5, ease: "easeOut" }}
+              >
+                <Text size="6" className="hero-title">
+                  Staff Frontend Engineer
+                </Text>
+              </motion.div>
+
+              {/* Tagline */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.9, duration: 0.5, ease: "easeOut" }}
+              >
+                <Text className="subtitle-refined hero-tagline">
+                  15+ Years Building Web Experiences
+                </Text>
+              </motion.div>
+
+              {/* CTA Buttons */}
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 1.1, duration: 0.5, ease: "easeOut" }}
+              >
+                <Flex direction="row" gap="3" className="hero-cta">
+                  <Button size="3" asChild style={{ cursor: "pointer" }}>
+                    <a href="#experience">View Experience</a>
+                  </Button>
+                  <Button size="3" variant="outline" asChild className="resume-button">
+                    <a href="/robert-abby-resume.pdf" download>
+                      <DownloadIcon /> Resume
+                    </a>
+                  </Button>
+                </Flex>
+              </motion.div>
+            </div>
+          </div>
+        </Container>
+      </motion.div>
     </Section>
   );
 }

--- a/app/components/Projects.css
+++ b/app/components/Projects.css
@@ -1,3 +1,45 @@
+/* Masonry grid layout */
+.projects-masonry {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
+/* Featured project spans full width with gold emphasis */
+.projects-masonry .project-card--featured {
+  grid-column: 1 / -1;
+  border-color: rgba(201, 169, 98, 0.4);
+  box-shadow: 0 0 30px rgba(201, 169, 98, 0.15);
+}
+
+.projects-masonry .project-card--featured:hover {
+  border-color: rgba(201, 169, 98, 0.6);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.4),
+    0 0 40px rgba(201, 169, 98, 0.2);
+}
+
+/* Gold gradient overlay for featured project visual */
+.project-card--featured .project-visual::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    135deg,
+    rgba(201, 169, 98, 0.1) 0%,
+    transparent 50%
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Mobile: single column */
+@media (max-width: 767px) {
+  .projects-masonry {
+    grid-template-columns: 1fr;
+  }
+}
+
 .project-card {
   overflow: hidden;
   padding: 0 !important;
@@ -5,8 +47,13 @@
 
 .project-visual {
   position: relative;
-  height: 140px;
+  height: 120px;
   overflow: hidden;
+}
+
+/* Featured project has taller visual */
+.project-card--featured .project-visual {
+  height: 160px;
 }
 
 .project-visual--blue {

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -64,77 +64,83 @@ export default function Projects() {
   return (
     <Box
       id="projects"
-      py="8"
+      py="9"
       style={{ background: "var(--sg-deep)", position: "relative", overflow: "hidden" }}
     >
       <GeometricPattern variant="hexagons" opacity={0.02} />
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
-        <Flex
-          align="center"
-          direction="column"
-          justify="center"
-        >
-        <Heading mb="8" size="8" className="section-title">
-          Projects
-        </Heading>
-        {PROJECTS.map((proj, index) => (
-          <Container
-            key={index}
-            size="3"
-            mx="4"
-            mb="8"
-            className={`sg-card project-card ${proj.featured ? 'sg-card--featured' : ''}`}
-          >
-            <Box className={`project-visual project-visual--${proj.gradientType}`}>
-              <Box className="project-visual-pattern" />
-              <Box className="project-visual-content">
-                <Badge size="1" className="sg-badge--featured">
-                  {proj.category}
-                </Badge>
-                <Heading size="6" className="project-visual-title">{proj.title}</Heading>
-              </Box>
+        <Container size="4" px="6">
+          {/* Asymmetric grid layout */}
+          <Flex direction={{ initial: "column", md: "row" }} gap="8" align="start">
+            {/* Left column - Section header */}
+            <Box style={{ flex: "0 0 200px" }}>
+              <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
+                Work
+              </Text>
+              <Heading size="8" className="section-title" style={{ textAlign: "left" }}>
+                Projects
+              </Heading>
             </Box>
-            <Box p="4">
-            {proj.callout && (
-              <Callout.Root mb="4">
-                <Callout.Icon>
-                  <InfoCircledIcon />
-                </Callout.Icon>
-                <Callout.Text>
-                  {proj.callout}
-                </Callout.Text>
-              </Callout.Root>
-            )}
-            <Box mb="4">
-              <Text mb="4">{proj.description}</Text>
-            </Box>
-            <Flex wrap="wrap" gap="2" mb="4">
-              {proj.tech.map((item, index) => (
-                <Badge size="2" key={index}>
-                  {item}
-                </Badge>
+
+            {/* Right column - Masonry grid */}
+            <Box style={{ flex: 1 }} className="projects-masonry">
+              {PROJECTS.map((proj, index) => (
+                <Box
+                  key={index}
+                  className={`sg-card project-card ${proj.featured ? 'project-card--featured' : ''}`}
+                >
+                  <Box className={`project-visual project-visual--${proj.gradientType}`}>
+                    <Box className="project-visual-pattern" />
+                    <Box className="project-visual-content">
+                      <Badge size="1" className="sg-badge--featured">
+                        {proj.category}
+                      </Badge>
+                      <Heading size="5" className="project-visual-title">{proj.title}</Heading>
+                    </Box>
+                  </Box>
+                  <Box p="4">
+                    {proj.callout && (
+                      <Callout.Root mb="3" size="1">
+                        <Callout.Icon>
+                          <InfoCircledIcon />
+                        </Callout.Icon>
+                        <Callout.Text>
+                          {proj.callout}
+                        </Callout.Text>
+                      </Callout.Root>
+                    )}
+                    <Text size="2" style={{ color: "var(--sg-text-secondary)", display: "block" }} mb="3">
+                      {proj.description}
+                    </Text>
+                    <Flex wrap="wrap" gap="1" mb="4">
+                      {proj.tech.map((item, techIndex) => (
+                        <Badge size="1" key={techIndex} className="sg-badge">
+                          {item}
+                        </Badge>
+                      ))}
+                    </Flex>
+                    <Flex gap="2">
+                      {proj.githubLink && (
+                        <Button size="1" variant="outline" asChild>
+                          <Link href={proj.githubLink} target="_blank">
+                            GitHub
+                          </Link>
+                        </Button>
+                      )}
+                      {proj.liveLink && (
+                        <Button size="1" asChild>
+                          <Link href={proj.liveLink} target={proj._target}>
+                            Demo
+                          </Link>
+                        </Button>
+                      )}
+                    </Flex>
+                  </Box>
+                </Box>
               ))}
-            </Flex>
-              <Box>
-                {proj.githubLink && (
-                  <Button asChild mb="2" mr="2">
-                    <Link href={proj.githubLink} target="_blank">
-                      Github Link
-                    </Link>
-                  </Button>
-                )}
-                {proj.liveLink && (
-                  <Button mb="2">
-                    <Link href={proj.liveLink} target={proj._target}>
-                      Demo Link
-                    </Link>
-                  </Button>
-                )}
-              </Box>
             </Box>
-          </Container>
-        ))}
-        </Flex>
+          </Flex>
+        </Container>
       </AnimatedSection>
     </Box>
   )

--- a/app/components/SectionDivider.tsx
+++ b/app/components/SectionDivider.tsx
@@ -1,0 +1,48 @@
+import { Box } from "@radix-ui/themes";
+
+interface SectionDividerProps {
+  variant?: "gold" | "subtle";
+}
+
+export default function SectionDivider({ variant = "gold" }: SectionDividerProps) {
+  const isGold = variant === "gold";
+
+  return (
+    <Box
+      style={{
+        position: "relative",
+        height: "60px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        overflow: "hidden",
+      }}
+    >
+      {/* Main line */}
+      <Box
+        style={{
+          position: "absolute",
+          width: "100%",
+          height: "1px",
+          background: isGold
+            ? "linear-gradient(90deg, transparent 0%, rgba(201, 169, 98, 0.1) 20%, rgba(201, 169, 98, 0.3) 50%, rgba(201, 169, 98, 0.1) 80%, transparent 100%)"
+            : "linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.05) 50%, transparent 100%)",
+        }}
+      />
+
+      {/* Center diamond accent */}
+      {isGold && (
+        <Box
+          style={{
+            position: "relative",
+            width: "8px",
+            height: "8px",
+            background: "var(--sg-gold)",
+            transform: "rotate(45deg)",
+            boxShadow: "0 0 12px var(--sg-gold-glow)",
+          }}
+        />
+      )}
+    </Box>
+  );
+}

--- a/app/components/Skills.tsx
+++ b/app/components/Skills.tsx
@@ -1,7 +1,10 @@
-import { Badge, Box, Container, Flex, Heading } from "@radix-ui/themes";
+import { Badge, Box, Container, Flex, Heading, Text } from "@radix-ui/themes";
 import GeometricPattern from "./GeometricPattern";
 import AnimatedSection from "./AnimatedSection";
 import StaggeredList from "./StaggeredList";
+
+// Hero skills displayed as prominent circular badges
+const HERO_SKILLS = ["TypeScript", "React", "Next.js", "Design Systems"];
 
 type SkillCategory = {
   featured: string[];
@@ -37,35 +40,57 @@ const SKILLS: Record<string, SkillCategory> = {
 
 export default function Skills() {
   return (
-    <Box id="skills" py="8" style={{ background: "var(--sg-deep)", position: "relative", overflow: "hidden" }}>
+    <Box id="skills" py="9" style={{ background: "var(--sg-deep)", position: "relative", overflow: "hidden" }}>
       <GeometricPattern variant="lines" opacity={0.02} />
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
-        <Flex direction="column" justify="center" align="center">
-          <Heading mb="8" size="8" className="section-title">Skills</Heading>
-          <Container size="3">
-            <Flex direction="column" gap="4">
-              {Object.entries(SKILLS).map(([category, { featured, other }]) => (
-                <Box key={category} mx="4" p="4" className="sg-card">
-                  <Heading mb="4" size="5">{category}</Heading>
-                  <StaggeredList style={{ display: "flex", flexDirection: "row", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                    {/* Featured skills with gold accent */}
-                    {featured.map((skill) => (
-                      <Badge size="3" key={skill} className="sg-badge--featured">
-                        {skill}
-                      </Badge>
-                    ))}
-                    {/* Standard skills */}
-                    {other.map((skill) => (
-                      <Badge size="2" key={skill}>
-                        {skill}
-                      </Badge>
-                    ))}
-                  </StaggeredList>
-                </Box>
-              ))}
-            </Flex>
-          </Container>
-        </Flex>
+        <Container size="4" px="6">
+          {/* Asymmetric grid layout */}
+          <Flex direction={{ initial: "column", md: "row" }} gap="8" align="start">
+            {/* Left column - Section header */}
+            <Box style={{ flex: "0 0 200px" }}>
+              <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
+                Expertise
+              </Text>
+              <Heading size="8" className="section-title" style={{ textAlign: "left" }}>
+                Skills
+              </Heading>
+
+              {/* Hero skill badges - circular prominent display */}
+              <Box className="skill-hero-badges" mt="6">
+                {HERO_SKILLS.map((skill) => (
+                  <Box key={skill} className="skill-hero-badge">
+                    {skill}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+
+            {/* Right column - Skill categories */}
+            <Box style={{ flex: 1 }}>
+              <Flex direction="column" gap="6">
+                {Object.entries(SKILLS).map(([category, { featured, other }]) => (
+                  <Box key={category} p="5" className="sg-card">
+                    <Heading mb="4" size="4" style={{ color: "var(--sg-secondary)" }}>{category}</Heading>
+                    <StaggeredList style={{ display: "flex", flexDirection: "row", gap: "var(--space-2)", flexWrap: "wrap" }}>
+                      {/* Featured skills with gold accent */}
+                      {featured.map((skill) => (
+                        <Badge size="3" key={skill} className="sg-badge--featured">
+                          {skill}
+                        </Badge>
+                      ))}
+                      {/* Standard skills */}
+                      {other.map((skill) => (
+                        <Badge size="2" key={skill} className="sg-badge">
+                          {skill}
+                        </Badge>
+                      ))}
+                    </StaggeredList>
+                  </Box>
+                ))}
+              </Flex>
+            </Box>
+          </Flex>
+        </Container>
       </AnimatedSection>
     </Box>
   )

--- a/app/components/StatsBar/index.tsx
+++ b/app/components/StatsBar/index.tsx
@@ -54,7 +54,7 @@ function AnimatedNumber({ value, suffix }: { value: number; suffix: string }) {
   }, [isInView, value, prefersReducedMotion]);
 
   return (
-    <span ref={ref} className="stat-number">
+    <span ref={ref} className="stat-number metric-impact">
       {displayValue}{suffix}
     </span>
   );

--- a/app/components/StatsBar/style.css
+++ b/app/components/StatsBar/style.css
@@ -1,7 +1,7 @@
 .stats-bar {
-  background: linear-gradient(180deg, var(--sg-surface) 0%, var(--sg-deep) 100%);
-  border-top: 1px solid rgba(74, 158, 255, 0.1);
-  border-bottom: 1px solid rgba(74, 158, 255, 0.1);
+  background: linear-gradient(180deg, var(--sg-surface) 0%, var(--sg-void) 100%);
+  border-top: 1px solid rgba(201, 169, 98, 0.15);
+  border-bottom: 1px solid rgba(201, 169, 98, 0.15);
   position: relative;
 }
 
@@ -11,7 +11,7 @@
   inset: 0;
   background: radial-gradient(
     ellipse at center,
-    rgba(74, 158, 255, 0.05) 0%,
+    rgba(201, 169, 98, 0.03) 0%,
     transparent 70%
   );
   pointer-events: none;
@@ -27,15 +27,28 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 0 1rem;
+  padding: 0 2rem;
   flex: 1;
-  min-width: 120px;
+  min-width: 140px;
+  position: relative;
 }
 
-/* Dividers between stats on desktop */
+/* Gold dividers between stats on desktop */
 @media (min-width: 640px) {
-  .stat-item:not(:last-child) {
-    border-right: 1px solid rgba(74, 158, 255, 0.15);
+  .stat-item:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1px;
+    height: 50%;
+    background: linear-gradient(
+      180deg,
+      transparent 0%,
+      var(--sg-gold) 50%,
+      transparent 100%
+    );
   }
 }
 
@@ -52,8 +65,9 @@
   font-family: var(--font-display);
   color: var(--sg-text-secondary);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-top: 0.5rem;
+  letter-spacing: 0.1em;
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
 }
 
 /* Mobile: 2x2 grid */
@@ -66,5 +80,9 @@
 
   .stat-item {
     padding: 0;
+  }
+
+  .stat-item::after {
+    display: none;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -18,17 +18,23 @@ body {
   --line-height-normal: 1.6;
   --line-height-relaxed: 1.75;
 
-  /* Sacred geometry palette */
-  --sg-void: #0a0c10;
-  --sg-deep: #0f1318;
-  --sg-surface: #161b22;
-  --sg-elevated: #1c2128;
+  /* Sacred geometry palette - refined luxury (deeper for drama) */
+  --sg-void: #050608;
+  --sg-deep: #0a0d12;
+  --sg-surface: #12161c;
+  --sg-elevated: #1a1f28;
 
   /* Accent colors - ethereal blues and golds */
   --sg-primary: #4a9eff;
   --sg-primary-glow: rgba(74, 158, 255, 0.4);
   --sg-secondary: #d4b872;
   --sg-secondary-glow: rgba(212, 184, 114, 0.3);
+
+  /* Richer gold spectrum for luxury aesthetic */
+  --sg-gold-deep: #8b6914;
+  --sg-gold: #c9a962;
+  --sg-gold-bright: #e8d5a3;
+  --sg-gold-glow: rgba(201, 169, 98, 0.4);
 
   /* Text */
   --sg-text-primary: rgba(255, 255, 255, 0.92);
@@ -39,6 +45,14 @@ body {
   --sg-gradient-hero: linear-gradient(135deg, #1a4a7a 0%, #0d2847 50%, #0a1628 100%);
   --sg-gradient-section: linear-gradient(180deg, var(--sg-deep) 0%, var(--sg-void) 100%);
   --sg-gradient-card: linear-gradient(145deg, var(--sg-elevated) 0%, var(--sg-surface) 100%);
+  --sg-gold-gradient: linear-gradient(135deg, var(--sg-gold-bright) 0%, var(--sg-gold) 50%, var(--sg-gold-deep) 100%);
+
+  /* Animation tokens */
+  --sg-transition-slow: 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  --sg-transition-medium: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Luxury shadows */
+  --sg-luxury-shadow: 0 25px 80px rgba(0, 0, 0, 0.6), 0 10px 30px rgba(0, 0, 0, 0.4);
 }
 
 body {
@@ -213,4 +227,147 @@ h2 {
 /* Footer link styles */
 .footer-link:hover {
   color: var(--sg-primary) !important;
+}
+
+/* ===========================================
+   LUXURY TYPOGRAPHY CLASSES
+   =========================================== */
+
+/* Dramatic display heading - for hero name */
+.display-dramatic {
+  font-family: var(--font-mystical);
+  font-size: clamp(4rem, 12vw, 8rem);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  line-height: 0.9;
+  text-transform: uppercase;
+  color: var(--sg-text-primary);
+}
+
+/* Refined subtitle - for hero tagline */
+.subtitle-refined {
+  font-family: var(--font-display);
+  font-size: clamp(1rem, 2.5vw, 1.5rem);
+  font-weight: 300;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--sg-secondary);
+}
+
+/* Impact metric - for stats numbers with gold gradient */
+.metric-impact {
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 6vw, 4.5rem);
+  font-weight: 700;
+  background: var(--sg-gold-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1;
+}
+
+/* Lead statement - oversized text for about section */
+.lead-statement {
+  font-family: var(--font-body);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--sg-secondary);
+}
+
+/* ===========================================
+   LUXURY UTILITY CLASSES
+   =========================================== */
+
+/* Gold text accent */
+.text-gold {
+  color: var(--sg-secondary);
+}
+
+/* Gold gradient text */
+.text-gold-gradient {
+  background: var(--sg-gold-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Gold glow effect */
+.glow-gold {
+  box-shadow: 0 0 40px var(--sg-gold-glow), 0 0 80px rgba(212, 184, 114, 0.15);
+}
+
+/* Shimmer animation for gold elements */
+@keyframes shimmer {
+  0% {
+    background-position: -200% center;
+  }
+  100% {
+    background-position: 200% center;
+  }
+}
+
+.shimmer-gold {
+  background: linear-gradient(
+    90deg,
+    var(--sg-secondary) 0%,
+    var(--sg-gold-bright) 25%,
+    var(--sg-secondary) 50%,
+    var(--sg-gold-bright) 75%,
+    var(--sg-secondary) 100%
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: shimmer 3s ease-in-out infinite;
+}
+
+/* Skill hero badge - circular featured skill display */
+.skill-hero-badge {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 2px solid var(--sg-secondary);
+  background: rgba(201, 169, 98, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--sg-secondary);
+  box-shadow: 0 0 20px var(--sg-gold-glow);
+  transition: var(--sg-transition-medium);
+  text-align: center;
+  padding: 0.5rem;
+}
+
+.skill-hero-badge:hover {
+  transform: scale(1.08);
+  box-shadow: 0 0 30px var(--sg-gold-glow);
+  border-color: var(--sg-gold-bright);
+}
+
+/* Skill hero badges container - 2x2 grid on mobile */
+.skill-hero-badges {
+  display: grid;
+  grid-template-columns: repeat(2, 80px);
+  gap: 0.75rem;
+  justify-content: start;
+}
+
+@media (max-width: 767px) {
+  .skill-hero-badges {
+    justify-content: center;
+    margin-top: 1.5rem;
+  }
+
+  .skill-hero-badge {
+    width: 70px;
+    height: 70px;
+    font-size: 0.6rem;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import Skills from "./components/Skills";
 import Experience from "./components/Experience";
 import Projects from "./components/Projects";
 import Footer from "./components/Footer";
+import SectionDivider from "./components/SectionDivider";
 
 export default function Home() {
   return (
@@ -16,12 +17,16 @@ export default function Home() {
       <Header />
       <Hero />
       <StatsBar />
+      <SectionDivider />
       <About />
+      <SectionDivider variant="subtle" />
       <Skills />
+      <SectionDivider />
       <Experience />
+      <SectionDivider variant="subtle" />
       <Projects />
       <Footer />
-		</Box>
+    </Box>
   )
 }
 


### PR DESCRIPTION
## Summary
- Implement refined luxury portfolio redesign with asymmetric layouts, gold accents, and enhanced typography
- Add skill hero badges with responsive 2x2 grid layout on mobile
- Create centered Experience section with gold timeline
- Add masonry grid for Projects with gold emphasis on featured cards
- Create SectionDivider component for visual separation between sections

## Changes
- **Hero**: Asymmetric grid layout with portrait sizing and diagonal accent
- **StatsBar**: Gold gradient dividers between metrics
- **About**: Asymmetric layout with left header, lead-statement typography
- **Skills**: Hero badges (80px circles) in 2x2 grid, responsive for mobile
- **Experience**: Centered layout with gold timeline and dots
- **Projects**: 2-column masonry grid, featured project full-width with gold emphasis
- **Footer**: Enhanced gold gradient divider
- **New**: SectionDivider component with gold/subtle variants
- **Globals**: Gold color spectrum, luxury typography classes, shimmer animation

## Test plan
- [ ] Verify Hero displays correctly on desktop and mobile
- [ ] Check Skills hero badges display as 2x2 grid on mobile
- [ ] Verify Experience section is centered with timeline visible
- [ ] Confirm featured project has gold border and glow
- [ ] Test section dividers appear between sections
- [ ] Verify responsive behavior across breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)