### PR TITLE
feat(skills): redesign section with editorial/magazine style

### DIFF
--- a/app/components/Skills.tsx
+++ b/app/components/Skills.tsx
@@ -1,17 +1,25 @@
+"use client";
+
 import { Badge, Box, Container, Flex, Heading, Text } from "@radix-ui/themes";
+import { motion } from "motion/react";
 import GeometricPattern from "./GeometricPattern";
 import AnimatedSection from "./AnimatedSection";
 import StaggeredList from "./StaggeredList";
 
-// Hero skills displayed as prominent circular badges
-const HERO_SKILLS = ["TypeScript", "React", "Next.js", "Design Systems"];
+// Core competencies for editorial hero display
+const CORE_COMPETENCIES = [
+  { skill: "TypeScript", emphasis: "Type-Safe" },
+  { skill: "React", emphasis: "Component" },
+  { skill: "Next.js", emphasis: "Full-Stack" },
+  { skill: "Design Systems", emphasis: "Systematic" },
+];
 
 type SkillCategory = {
   featured: string[];
   other: string[];
 };
 
-const SKILLS: Record<string, SkillCategory> = {
+const SKILL_CATEGORIES: Record<string, SkillCategory> = {
   "Languages & Frameworks": {
     featured: ["TypeScript", "React", "Next.js"],
     other: [
@@ -40,14 +48,14 @@ const SKILLS: Record<string, SkillCategory> = {
 
 export default function Skills() {
   return (
-    <Box id="skills" py="9" style={{ background: "var(--sg-deep)", position: "relative", overflow: "hidden" }}>
+    <Box id="skills" py="9" className="skills-section">
       <GeometricPattern variant="lines" opacity={0.02} />
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
         <Container size="4" px="6">
           {/* Asymmetric grid layout */}
           <Flex direction={{ initial: "column", md: "row" }} gap="8" align="start">
-            {/* Left column - Section header */}
-            <Box style={{ flex: "0 0 200px" }}>
+            {/* Left column - Section header + Hero statements */}
+            <Box className="skills-left-column">
               <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
                 Expertise
               </Text>
@@ -55,44 +63,57 @@ export default function Skills() {
                 Skills
               </Heading>
 
-              {/* Hero skill badges - circular prominent display */}
-              <Box className="skill-hero-badges" mt="6">
-                {HERO_SKILLS.map((skill) => (
-                  <Box key={skill} className="skill-hero-badge">
-                    {skill}
-                  </Box>
+              {/* Editorial Hero Statements */}
+              <Box className="skills-hero-statements">
+                {CORE_COMPETENCIES.map((item, index) => (
+                  <motion.div
+                    key={item.skill}
+                    className="skill-statement"
+                    initial={{ opacity: 0, x: -20 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    transition={{ delay: index * 0.1, duration: 0.5, ease: "easeOut" }}
+                    viewport={{ once: true, amount: 0.3 }}
+                  >
+                    <span className="skill-statement-emphasis">{item.emphasis}</span>
+                    <span className="skill-statement-skill">{item.skill}</span>
+                  </motion.div>
                 ))}
               </Box>
             </Box>
 
-            {/* Right column - Skill categories */}
-            <Box style={{ flex: 1 }}>
-              <Flex direction="column" gap="6">
-                {Object.entries(SKILLS).map(([category, { featured, other }]) => (
-                  <Box key={category} p="5" className="sg-card">
-                    <Heading mb="4" size="4" style={{ color: "var(--sg-secondary)" }}>{category}</Heading>
-                    <StaggeredList style={{ display: "flex", flexDirection: "row", gap: "var(--space-2)", flexWrap: "wrap" }}>
-                      {/* Featured skills with gold accent */}
+            {/* Right column - Category cards with equal weight */}
+            <Box className="skills-categories">
+              <StaggeredList style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+                {Object.entries(SKILL_CATEGORIES).map(([category, { featured, other }]) => (
+                  <Box key={category} className="sg-card skill-category-card">
+                    {/* Category header */}
+                    <h3 className="skill-category-title">{category}</h3>
+
+                    {/* Featured skills as pull quotes */}
+                    <Box className="skill-featured-container">
                       {featured.map((skill) => (
-                        <Badge size="3" key={skill} className="sg-badge--featured">
+                        <Text key={skill} className="skill-pull-quote">
                           {skill}
-                        </Badge>
+                        </Text>
                       ))}
-                      {/* Standard skills */}
+                    </Box>
+
+                    {/* Supporting skills */}
+                    <Flex wrap="wrap" gap="2" className="skill-supporting-container">
                       {other.map((skill) => (
-                        <Badge size="2" key={skill} className="sg-badge">
+                        <Badge key={skill} size="2" className="sg-badge">
                           {skill}
                         </Badge>
                       ))}
-                    </StaggeredList>
+                    </Flex>
                   </Box>
                 ))}
-              </Flex>
+              </StaggeredList>
             </Box>
           </Flex>
         </Container>
       </AnimatedSection>
     </Box>
-  )
+  );
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -323,45 +323,243 @@ h2 {
   animation: shimmer 3s ease-in-out infinite;
 }
 
-/* Skill hero badge - circular featured skill display with fluid sizing */
-.skill-hero-badge {
-  width: clamp(60px, 18vw, 80px);
-  height: clamp(60px, 18vw, 80px);
-  border-radius: 50%;
-  border: 2px solid var(--sg-secondary);
-  background: rgba(201, 169, 98, 0.08);
+
+/* ===========================================
+   SKILLS SECTION - EDITORIAL STYLE
+   =========================================== */
+
+/* Section container */
+.skills-section {
+  background: var(--sg-deep);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Left column layout */
+.skills-left-column {
+  flex: 0 0 280px;
+}
+
+/* Hero statements container */
+.skills-hero-statements {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+/* Individual skill statement - editorial style */
+.skill-statement {
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+  position: relative;
+  padding-left: 1rem;
+  border-left: 2px solid var(--sg-secondary);
+}
+
+.skill-statement-emphasis {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--sg-text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.skill-statement-skill {
+  font-family: var(--font-mystical);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  background: var(--sg-gold-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Categories container */
+.skills-categories {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+/* Category card - equal weight for all */
+.skill-category-card {
+  padding: 2rem !important;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Category title - editorial heading */
+.skill-category-title {
+  font-family: var(--font-mystical);
+  font-size: clamp(1.25rem, 2.5vw, 1.5rem);
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  color: var(--sg-text-primary);
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(212, 184, 114, 0.3);
+  position: relative;
+  margin: 0;
+}
+
+/* Gold accent line under category title */
+.skill-category-title::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 60px;
+  height: 2px;
+  background: var(--sg-secondary);
+}
+
+/* Featured skills - pull quote style */
+.skill-featured-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  padding: 0.5rem 0;
+}
+
+.skill-pull-quote {
+  font-family: var(--font-body);
+  font-size: 1.125rem;
+  font-weight: 500;
+  font-style: italic;
+  color: var(--sg-secondary);
+  position: relative;
+  padding-left: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-family: var(--font-display);
-  font-size: clamp(0.55rem, 1.5vw, 0.7rem);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-  color: var(--sg-secondary);
-  box-shadow: 0 0 20px var(--sg-gold-glow);
-  transition: var(--sg-transition-medium);
-  text-align: center;
-  padding: 0.5rem;
+  gap: 0.75rem;
 }
 
-.skill-hero-badge:hover {
-  transform: scale(1.08);
-  box-shadow: 0 0 30px var(--sg-gold-glow);
-  border-color: var(--sg-gold-bright);
+.skill-pull-quote::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--sg-secondary);
+  border-radius: 50%;
+  flex-shrink: 0;
+  opacity: 0.6;
 }
 
-/* Skill hero badges container - fluid 2x2 grid */
-.skill-hero-badges {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(60px, 80px));
-  gap: clamp(0.5rem, 2vw, 0.75rem);
-  justify-content: start;
+/* Supporting skills container */
+.skill-supporting-container {
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(74, 158, 255, 0.1);
+  margin-top: auto;
 }
 
+/* ===========================================
+   SKILLS SECTION - RESPONSIVE
+   =========================================== */
+
+/* Tablet - adjust layout */
+@media (max-width: 1023px) {
+  .skills-left-column {
+    flex: 0 0 220px;
+  }
+
+  .skill-statement-skill {
+    font-size: clamp(1.25rem, 2.5vw, 1.75rem);
+  }
+}
+
+/* Tablet portrait and mobile */
 @media (max-width: 767px) {
-  .skill-hero-badges {
+  .skills-left-column {
+    flex: 1;
+    width: 100%;
+  }
+
+  .skills-hero-statements {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
     justify-content: center;
     margin-top: 1.5rem;
+  }
+
+  .skill-statement {
+    flex: 0 0 calc(50% - 0.5rem);
+    text-align: center;
+    border-left: none;
+    padding-left: 0;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid var(--sg-secondary);
+  }
+
+  .skill-statement-emphasis {
+    font-size: 0.6rem;
+  }
+
+  .skill-statement-skill {
+    font-size: 1rem;
+  }
+
+  .skill-category-card {
+    padding: 1.5rem !important;
+  }
+
+  .skill-category-title {
+    font-size: 1.125rem;
+    text-align: center;
+  }
+
+  .skill-category-title::after {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .skill-featured-container {
+    justify-content: center;
+  }
+
+  .skill-pull-quote {
+    font-size: 1rem;
+  }
+
+  .skill-supporting-container {
+    justify-content: center;
+  }
+
+  /* Section title alignment for mobile */
+  .skills-section .section-title {
+    text-align: center;
+  }
+
+  .skills-section .section-title::after {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .skills-section .section-subtitle {
+    text-align: center;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .skills-hero-statements {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .skill-statement {
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: 200px;
+  }
+
+  .skill-statement-skill {
+    font-size: 1.25rem;
   }
 }


### PR DESCRIPTION
## Summary

- Replace circular badge design with sophisticated editorial/magazine approach
- Add hero statements with emphasis labels and gold gradient text
- Convert featured skills to italic pull-quote style with gold bullets
- Implement responsive layouts across all breakpoints

## Changes

**Hero Statements (replacing circles):**
- 4 core skills as dramatic typographic statements
- Small "emphasis" labels (Type-Safe, Component, Full-Stack, Systematic)
- Large Cinzel font with gold gradient text
- Left gold border on desktop, bottom border on mobile

**Category Cards:**
- Cinzel typography headers with gold underline accent
- Featured skills as italic gold pull-quotes with bullet points
- Proper card spacing via flex gap

**Responsive Behavior:**
- Desktop: Two-column layout with vertical hero statements
- Tablet: Single column, vertical hero stack
- Mobile: 2x2 centered hero grid with bottom borders

## Test plan

- [ ] Verify desktop layout (1400px+) shows two-column with vertical hero statements
- [ ] Verify tablet layout (768px) shows single column with proper spacing
- [ ] Verify mobile layout (480px) shows 2x2 hero grid centered
- [ ] Confirm card spacing is visible between all category cards
- [ ] Check animations work on scroll into view

Resolves SG-139

🤖 Generated with [Claude Code](https://claude.com/claude-code)