### PR TITLE
fix(mobile): reduce excessive spacing in About and Projects sections

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -16,9 +16,9 @@ export default function About() {
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
         <Container size="4" px="6">
           {/* Asymmetric grid layout */}
-          <Flex direction={{ initial: "column", md: "row" }} gap="8" align="start">
+          <Flex direction={{ initial: "column", md: "row" }} gap={{ initial: "4", md: "8" }} align="start">
             {/* Left column - Section header */}
-            <Box style={{ flex: "0 0 200px" }}>
+            <Box className="section-header-column">
               <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
                 Background
               </Text>

--- a/app/components/Projects.tsx
+++ b/app/components/Projects.tsx
@@ -71,9 +71,9 @@ export default function Projects() {
       <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
         <Container size="4" px="6">
           {/* Asymmetric grid layout */}
-          <Flex direction={{ initial: "column", md: "row" }} gap="8" align="start">
+          <Flex direction={{ initial: "column", md: "row" }} gap={{ initial: "4", md: "8" }} align="start">
             {/* Left column - Section header */}
-            <Box style={{ flex: "0 0 200px" }}>
+            <Box className="section-header-column">
               <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
                 Work
               </Text>

--- a/app/globals.css
+++ b/app/globals.css
@@ -113,6 +113,17 @@ h2 {
   color: var(--sg-secondary);
 }
 
+/* Section header column - fixed width on desktop, auto on mobile */
+.section-header-column {
+  flex: 0 0 auto;
+}
+
+@media (min-width: 768px) {
+  .section-header-column {
+    flex: 0 0 200px;
+  }
+}
+
 /* Sacred geometry cards */
 .sg-card {
   background: var(--sg-gradient-card);


### PR DESCRIPTION
## Summary
- Fixed excessive spacing between section titles and content in About and Projects sections on mobile
- Root cause: `flex: 0 0 200px` became a fixed height on mobile when flex direction changed to column
- Solution: Created responsive `.section-header-column` CSS class with auto sizing on mobile, fixed 200px width on desktop
- Also reduced flex gap from 8 to 4 on mobile for tighter spacing

## Test plan
- [ ] Verify About section spacing on mobile (390px width)
- [ ] Verify Projects section spacing on mobile
- [ ] Verify desktop layout still has asymmetric side-by-side layout

Closes SG-140

🤖 Generated with [Claude Code](https://claude.com/claude-code)