### PR TITLE
fix(mobile): resolve animation issues for StatsBar and AnimatedSection

### DIFF
--- a/app/components/AnimatedSection/index.tsx
+++ b/app/components/AnimatedSection/index.tsx
@@ -34,7 +34,7 @@ export default function AnimatedSection({
       }}
       viewport={{
         once: true,
-        amount: 0.2
+        amount: 0.1
       }}
     >
       {children}

--- a/app/components/StatsBar/index.tsx
+++ b/app/components/StatsBar/index.tsx
@@ -21,7 +21,7 @@ const STATS: Stat[] = [
 function AnimatedNumber({ value, suffix }: { value: number; suffix: string }) {
   const [displayValue, setDisplayValue] = useState(0);
   const ref = useRef<HTMLSpanElement>(null);
-  const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const isInView = useInView(ref, { once: true });
   const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fix Lighthouse Score counter staying at 0 on mobile by removing restrictive `margin: "-100px"` from `useInView` hook
- Fix Experience section requiring too much scrolling before fading in by reducing viewport `amount` from 0.2 to 0.1

## Root Cause
- **StatsBar**: The 4th stat (Lighthouse Score) in the 2x2 mobile grid never met the -100px inset threshold
- **AnimatedSection**: 20% visibility requirement was too high for tall sections on small viewports

## Test plan
- [ ] Test on mobile viewport in Chrome DevTools
- [ ] Deploy to production and verify on actual mobile device
- [ ] Confirm all 4 stats animate correctly
- [ ] Confirm Experience section fades in earlier when scrolling

Closes SG-143

🤖 Generated with [Claude Code](https://claude.com/claude-code)