### PR TITLE
feat: Phase 3 — Case Studies with diagrams and homepage teaser

### DIFF
--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from "next/navigation";
+import { Metadata } from "next";
+import { Box } from "@radix-ui/themes";
+import Header from "../../components/Header";
+import CaseStudyContent from "../components/CaseStudyContent";
+import { CASE_STUDIES, getCaseStudyBySlug } from "../data";
+import "../style.css";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return CASE_STUDIES.map((cs) => ({ slug: cs.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const caseStudy = getCaseStudyBySlug(slug);
+
+  if (!caseStudy) {
+    return { title: "Not Found" };
+  }
+
+  return {
+    title: `${caseStudy.title} | Rob Abby`,
+    description: caseStudy.subtitle,
+    openGraph: {
+      title: `${caseStudy.title} | Rob Abby`,
+      description: caseStudy.subtitle,
+      type: "article",
+    },
+  };
+}
+
+export default async function CaseStudyPage({ params }: PageProps) {
+  const { slug } = await params;
+  const caseStudy = getCaseStudyBySlug(slug);
+
+  if (!caseStudy) {
+    notFound();
+  }
+
+  return (
+    <Box style={{ background: "var(--color-bg)", minHeight: "100vh" }}>
+      <Header variant="subpage" />
+      <CaseStudyContent caseStudy={caseStudy} />
+    </Box>
+  );
+}

--- a/app/case-studies/components/CaseStudyContent.tsx
+++ b/app/case-studies/components/CaseStudyContent.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+import { CaseStudy, CASE_STUDIES } from "../data";
+import DiagramRenderer from "./DiagramRenderer";
+
+interface CaseStudyContentProps {
+  caseStudy: CaseStudy;
+}
+
+export default function CaseStudyContent({ caseStudy }: CaseStudyContentProps) {
+  const currentIndex = CASE_STUDIES.findIndex(
+    (cs) => cs.slug === caseStudy.slug
+  );
+  const prevStudy =
+    currentIndex > 0 ? CASE_STUDIES[currentIndex - 1] : CASE_STUDIES[CASE_STUDIES.length - 1];
+  const nextStudy =
+    currentIndex < CASE_STUDIES.length - 1 ? CASE_STUDIES[currentIndex + 1] : CASE_STUDIES[0];
+
+  return (
+    <>
+      {/* Hero */}
+      <div className="cs-hero">
+        <div className="cs-hero-meta">
+          <span>{caseStudy.company}</span>
+          <span className="cs-hero-meta-separator">/</span>
+          <span>{caseStudy.role}</span>
+          <span className="cs-hero-meta-separator">/</span>
+          <span>{caseStudy.period}</span>
+        </div>
+        <h1 className="cs-hero-title">{caseStudy.title}</h1>
+        <p className="cs-hero-subtitle">{caseStudy.subtitle}</p>
+      </div>
+
+      {/* Metrics bar */}
+      <div className="cs-metrics-bar card">
+        {caseStudy.metrics.map((metric) => (
+          <div key={metric.label} className="cs-metric">
+            <div className="cs-metric-value">{metric.value}</div>
+            <div className="cs-metric-label">{metric.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Content sections */}
+      <div className="cs-body">
+        {caseStudy.sections.map((section) => (
+          <section key={section.heading}>
+            <h2 className="cs-section-heading">{section.heading}</h2>
+            {section.content.map((paragraph, i) => (
+              <p key={i} className="about-narrative">
+                {paragraph}
+              </p>
+            ))}
+
+            {/* Render diagrams after the Architecture section */}
+            {section.heading === "Architecture" &&
+              caseStudy.diagramIds.length > 0 && (
+                <>
+                  {caseStudy.diagramIds.map((diagramId) => (
+                    <div key={diagramId} className="card cs-diagram-wrapper">
+                      <DiagramRenderer diagramId={diagramId} />
+                    </div>
+                  ))}
+                </>
+              )}
+          </section>
+        ))}
+
+        {/* Tech tags */}
+        <div className="cs-tech">
+          <div className="cs-tech-label">Technologies</div>
+          <div className="cs-tech-list">
+            {caseStudy.tech.map((tech) => (
+              <span key={tech} className="badge">
+                {tech}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation footer */}
+      <nav className="cs-nav" aria-label="Case study navigation">
+        {prevStudy && prevStudy.slug !== caseStudy.slug && (
+          <Link
+            href={`/case-studies/${prevStudy.slug}`}
+            className="card cs-nav-card"
+          >
+            <div className="cs-nav-label">Previous Case Study</div>
+            <div className="cs-nav-title">{prevStudy.title}</div>
+          </Link>
+        )}
+        {nextStudy && nextStudy.slug !== caseStudy.slug && (
+          <Link
+            href={`/case-studies/${nextStudy.slug}`}
+            className="card cs-nav-card"
+          >
+            <div className="cs-nav-label">Next Case Study</div>
+            <div className="cs-nav-title">{nextStudy.title}</div>
+          </Link>
+        )}
+        <Link href="/" className="card cs-nav-card cs-nav-home">
+          <div className="cs-nav-label">Portfolio</div>
+          <div className="cs-nav-title">Back to Homepage</div>
+        </Link>
+      </nav>
+    </>
+  );
+}

--- a/app/case-studies/components/DiagramRenderer.tsx
+++ b/app/case-studies/components/DiagramRenderer.tsx
@@ -1,0 +1,41 @@
+import VenuePageArchitecture from "./diagrams/VenuePageArchitecture";
+import MetricsBeforeAfter from "./diagrams/MetricsBeforeAfter";
+import TeamStructure from "./diagrams/TeamStructure";
+import DesignSystemLayers from "./diagrams/DesignSystemLayers";
+
+const DIAGRAM_MAP: Record<string, React.ComponentType> = {
+  "venue-page-architecture": VenuePageArchitecture,
+  "metrics-before-after": MetricsBeforeAfter,
+  "team-structure": TeamStructure,
+  "design-system-layers": DesignSystemLayers,
+};
+
+const DIAGRAM_CAPTIONS: Record<string, string> = {
+  "venue-page-architecture":
+    "Component architecture: SearchFilters, MapView, ResultsList, and GraphQL data layer",
+  "metrics-before-after":
+    "Before and after: key performance and accessibility metrics",
+  "team-structure":
+    "Organizational evolution from siloed teams to a hub-and-spoke UX practice",
+  "design-system-layers":
+    "Design system stack: Material Design foundation through product UIs",
+};
+
+export default function DiagramRenderer({ diagramId }: { diagramId: string }) {
+  const DiagramComponent = DIAGRAM_MAP[diagramId];
+
+  if (!DiagramComponent) {
+    return null;
+  }
+
+  return (
+    <figure>
+      <DiagramComponent />
+      {DIAGRAM_CAPTIONS[diagramId] && (
+        <figcaption className="cs-diagram-caption">
+          {DIAGRAM_CAPTIONS[diagramId]}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/app/case-studies/components/diagrams/DesignSystemLayers.tsx
+++ b/app/case-studies/components/diagrams/DesignSystemLayers.tsx
@@ -1,0 +1,199 @@
+export default function DesignSystemLayers() {
+  const layers = [
+    {
+      label: "Product UIs",
+      subtitle: "Applications \u2014 unified across all products",
+      y: 32,
+      width: 340,
+      opacity: 1.0,
+      strokeOpacity: 1.0,
+    },
+    {
+      label: "Salesforce Integration",
+      subtitle: "Embedding \u2014 auth, cross-origin, state sync",
+      y: 120,
+      width: 400,
+      opacity: 0.7,
+      strokeOpacity: 0.8,
+    },
+    {
+      label: "Ember.js Components",
+      subtitle: "Component Library \u2014 iframe-safe, Lightning-aware",
+      y: 208,
+      width: 460,
+      opacity: 0.45,
+      strokeOpacity: 0.6,
+    },
+    {
+      label: "Material Design",
+      subtitle: "Foundation \u2014 tokens, color, typography, spacing",
+      y: 296,
+      width: 520,
+      opacity: 0.2,
+      strokeOpacity: 0.35,
+    },
+  ];
+
+  const boxHeight = 72;
+
+  return (
+    <svg
+      viewBox="0 0 600 400"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Design system technology stack showing four layers from bottom to top: Material Design foundation, Ember.js component library, Salesforce integration layer, and Product UIs at the top"
+    >
+      <defs>
+        {/* Gradient for layer fills — primary color at varying opacities */}
+        <linearGradient id="layer-gradient-0" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.25" />
+          <stop offset="100%" stopColor="var(--color-accent)" stopOpacity="0.15" />
+        </linearGradient>
+        <linearGradient id="layer-gradient-1" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.18" />
+          <stop offset="100%" stopColor="var(--color-accent)" stopOpacity="0.08" />
+        </linearGradient>
+        <linearGradient id="layer-gradient-2" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.10" />
+          <stop offset="100%" stopColor="var(--color-accent)" stopOpacity="0.04" />
+        </linearGradient>
+        <linearGradient id="layer-gradient-3" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="var(--color-primary)" stopOpacity="0.05" />
+          <stop offset="100%" stopColor="var(--color-accent)" stopOpacity="0.02" />
+        </linearGradient>
+      </defs>
+
+      {layers.map((layer, i) => {
+        const x = (600 - layer.width) / 2;
+
+        return (
+          <g key={layer.label}>
+            {/* Layer box */}
+            <rect
+              x={x}
+              y={layer.y}
+              width={layer.width}
+              height={boxHeight}
+              rx="8"
+              fill={`url(#layer-gradient-${i})`}
+            />
+            <rect
+              x={x}
+              y={layer.y}
+              width={layer.width}
+              height={boxHeight}
+              rx="8"
+              fill="none"
+              stroke="var(--color-primary)"
+              strokeWidth="1"
+              opacity={layer.strokeOpacity}
+            />
+
+            {/* Layer background surface */}
+            <rect
+              x={x}
+              y={layer.y}
+              width={layer.width}
+              height={boxHeight}
+              rx="8"
+              fill="var(--color-surface)"
+              opacity={0.4}
+            />
+
+            {/* Layer label */}
+            <text
+              x="300"
+              y={layer.y + 32}
+              textAnchor="middle"
+              fontFamily="var(--font-display)"
+              fontSize="15"
+              fontWeight="500"
+              fill="var(--color-text)"
+              opacity={0.5 + layer.opacity * 0.5}
+            >
+              {layer.label}
+            </text>
+
+            {/* Layer subtitle */}
+            <text
+              x="300"
+              y={layer.y + 52}
+              textAnchor="middle"
+              fontFamily="var(--font-body)"
+              fontSize="10.5"
+              fill="var(--color-text-2)"
+              opacity={0.4 + layer.opacity * 0.5}
+            >
+              {layer.subtitle}
+            </text>
+
+            {/* Left accent bar showing hierarchy */}
+            <rect
+              x={x + 1}
+              y={layer.y + 8}
+              width="3"
+              height={boxHeight - 16}
+              rx="1.5"
+              fill="var(--color-primary)"
+              opacity={layer.opacity}
+            />
+
+            {/* Upward connector line (except top layer) */}
+            {i > 0 && (
+              <line
+                x1="300"
+                y1={layer.y}
+                x2="300"
+                y2={layer.y - (layer.y - layers[i - 1].y - boxHeight)}
+                stroke="var(--color-primary)"
+                strokeWidth="1"
+                opacity="0.2"
+                strokeDasharray="4 3"
+              />
+            )}
+          </g>
+        );
+      })}
+
+      {/* Directional annotation — bottom to top */}
+      <text
+        x="567"
+        y="378"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="9"
+        letterSpacing="0.08em"
+        fill="var(--color-text-muted)"
+      >
+        FOUNDATION
+      </text>
+      <line
+        x1="567"
+        y1="370"
+        x2="567"
+        y2="52"
+        stroke="var(--color-text-muted)"
+        strokeWidth="0.75"
+        opacity="0.4"
+      />
+      <path
+        d="M563,58 L567,46 L571,58"
+        fill="none"
+        stroke="var(--color-text-muted)"
+        strokeWidth="0.75"
+        opacity="0.4"
+      />
+      <text
+        x="567"
+        y="42"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="9"
+        letterSpacing="0.08em"
+        fill="var(--color-text-muted)"
+      >
+        PRODUCT
+      </text>
+    </svg>
+  );
+}

--- a/app/case-studies/components/diagrams/MetricsBeforeAfter.tsx
+++ b/app/case-studies/components/diagrams/MetricsBeforeAfter.tsx
@@ -1,0 +1,196 @@
+export default function MetricsBeforeAfter() {
+  const metrics = [
+    {
+      label: "Lighthouse Accessibility",
+      before: "78",
+      after: "95",
+      progress: 0.95,
+    },
+    {
+      label: "Bundle Size",
+      before: "baseline",
+      after: "-40%",
+      progress: 0.6,
+    },
+    {
+      label: "Page Load Time",
+      before: "baseline",
+      after: "-2.3s",
+      progress: 0.7,
+    },
+    {
+      label: "Venue Inquiries",
+      before: "baseline",
+      after: "+150%",
+      progress: 1.0,
+    },
+  ];
+
+  const rowHeight = 60;
+  const startY = 68;
+
+  return (
+    <svg
+      viewBox="0 0 600 320"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Before and after metrics comparison showing improvements: Lighthouse Accessibility from 78 to 95, Bundle Size reduced by 40 percent, Page Load Time reduced by 2.3 seconds, and Venue Inquiries increased by 150 percent"
+    >
+      {/* Column headers */}
+      <text
+        x="200"
+        y="32"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="12"
+        fontWeight="500"
+        letterSpacing="0.1em"
+        fill="var(--color-text-muted)"
+      >
+        BEFORE
+      </text>
+      <text
+        x="400"
+        y="32"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="12"
+        fontWeight="500"
+        letterSpacing="0.1em"
+        fill="var(--color-accent)"
+      >
+        AFTER
+      </text>
+
+      {/* Header divider */}
+      <line
+        x1="40"
+        y1="44"
+        x2="560"
+        y2="44"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+
+      {metrics.map((metric, i) => {
+        const y = startY + i * rowHeight;
+        const barY = y + 18;
+        const barWidth = 160;
+        const barHeight = 4;
+        const filledWidth = barWidth * metric.progress;
+
+        return (
+          <g key={metric.label}>
+            {/* Alternating subtle row background */}
+            {i % 2 === 0 && (
+              <rect
+                x="30"
+                y={y - 16}
+                width="540"
+                height={rowHeight}
+                rx="4"
+                fill="var(--color-surface)"
+                opacity="0.5"
+              />
+            )}
+
+            {/* Metric label */}
+            <text
+              x="48"
+              y={y + 4}
+              fontFamily="var(--font-body)"
+              fontSize="13"
+              fontWeight="400"
+              fill="var(--color-text)"
+            >
+              {metric.label}
+            </text>
+
+            {/* Before value */}
+            <text
+              x="200"
+              y={y + 4}
+              textAnchor="middle"
+              fontFamily="var(--font-display)"
+              fontSize="16"
+              fontWeight="400"
+              fill="var(--color-text-muted)"
+            >
+              {metric.before}
+            </text>
+
+            {/* Arrow separator */}
+            <line
+              x1="268"
+              y1={y}
+              x2="320"
+              y2={y}
+              stroke="var(--color-border)"
+              strokeWidth="1"
+            />
+            <path
+              d={`M316,${y - 4} L324,${y} L316,${y + 4}`}
+              fill="none"
+              stroke="var(--color-accent)"
+              strokeWidth="1.5"
+            />
+
+            {/* After value */}
+            <text
+              x="400"
+              y={y + 5}
+              textAnchor="middle"
+              fontFamily="var(--font-display)"
+              fontSize="20"
+              fontWeight="600"
+              fill="var(--color-primary)"
+            >
+              {metric.after}
+            </text>
+
+            {/* Progress bar track */}
+            <rect
+              x="460"
+              y={barY}
+              width={barWidth}
+              height={barHeight}
+              rx="2"
+              fill="var(--color-border)"
+            />
+
+            {/* Progress bar fill */}
+            <rect
+              x="460"
+              y={barY}
+              width={filledWidth}
+              height={barHeight}
+              rx="2"
+              fill="var(--color-primary)"
+            />
+
+            {/* Glow on progress bar fill end */}
+            <circle
+              cx={460 + filledWidth}
+              cy={barY + barHeight / 2}
+              r="3"
+              fill="var(--color-primary)"
+              opacity="0.6"
+            />
+
+            {/* Row divider (except last) */}
+            {i < metrics.length - 1 && (
+              <line
+                x1="48"
+                y1={y + rowHeight / 2 + 6}
+                x2="552"
+                y2={y + rowHeight / 2 + 6}
+                stroke="var(--color-border-subtle)"
+                strokeWidth="1"
+              />
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/app/case-studies/components/diagrams/TeamStructure.tsx
+++ b/app/case-studies/components/diagrams/TeamStructure.tsx
@@ -1,0 +1,387 @@
+export default function TeamStructure() {
+  return (
+    <svg
+      viewBox="0 0 700 350"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Team structure evolution diagram showing the transition from embedded developers in separate product teams to a centralized UI/UX team using a hub-and-spoke model serving Product A, Product B, and Product C"
+    >
+      {/* ========== BEFORE STATE (left side) ========== */}
+
+      {/* Before label */}
+      <text
+        x="155"
+        y="30"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="12"
+        fontWeight="500"
+        letterSpacing="0.12em"
+        fill="var(--color-text-muted)"
+      >
+        BEFORE
+      </text>
+      <line
+        x1="80"
+        y1="40"
+        x2="230"
+        y2="40"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+
+      {/* Product Team A */}
+      <rect
+        x="50"
+        y="60"
+        width="210"
+        height="72"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="155"
+        y="86"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Product Team A
+      </text>
+      <rect
+        x="118"
+        y="98"
+        width="74"
+        height="24"
+        rx="4"
+        fill="var(--color-elevated)"
+        stroke="var(--color-text-muted)"
+        strokeWidth="0.75"
+      />
+      <text
+        x="155"
+        y="115"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        Dev
+      </text>
+
+      {/* Product Team B */}
+      <rect
+        x="50"
+        y="148"
+        width="210"
+        height="72"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="155"
+        y="174"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Product Team B
+      </text>
+      <rect
+        x="118"
+        y="186"
+        width="74"
+        height="24"
+        rx="4"
+        fill="var(--color-elevated)"
+        stroke="var(--color-text-muted)"
+        strokeWidth="0.75"
+      />
+      <text
+        x="155"
+        y="203"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        Dev
+      </text>
+
+      {/* Product Team C */}
+      <rect
+        x="50"
+        y="236"
+        width="210"
+        height="72"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="155"
+        y="262"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Product Team C
+      </text>
+      <rect
+        x="118"
+        y="274"
+        width="74"
+        height="24"
+        rx="4"
+        fill="var(--color-elevated)"
+        stroke="var(--color-text-muted)"
+        strokeWidth="0.75"
+      />
+      <text
+        x="155"
+        y="291"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        Dev
+      </text>
+
+      {/* "No shared process" annotation */}
+      <text
+        x="155"
+        y="332"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontStyle="italic"
+        fill="var(--color-text-muted)"
+      >
+        No shared process or components
+      </text>
+
+      {/* ========== TRANSITION ARROW ========== */}
+      <line
+        x1="290"
+        y1="184"
+        x2="370"
+        y2="184"
+        stroke="var(--color-primary)"
+        strokeWidth="2"
+      />
+      <path
+        d="M364,178 L376,184 L364,190"
+        fill="none"
+        stroke="var(--color-primary)"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* ========== AFTER STATE (right side) ========== */}
+
+      {/* After label */}
+      <text
+        x="530"
+        y="30"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="12"
+        fontWeight="500"
+        letterSpacing="0.12em"
+        fill="var(--color-accent)"
+      >
+        AFTER
+      </text>
+      <line
+        x1="455"
+        y1="40"
+        x2="605"
+        y2="40"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+        opacity="0.4"
+      />
+
+      {/* Central UI/UX Team hub */}
+      <rect
+        x="440"
+        y="110"
+        width="180"
+        height="80"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      {/* Subtle glow */}
+      <rect
+        x="440"
+        y="110"
+        width="180"
+        height="80"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="6"
+        opacity="0.2"
+      />
+      <text
+        x="530"
+        y="142"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="15"
+        fontWeight="600"
+        fill="var(--color-text)"
+      >
+        UI/UX Team
+      </text>
+      <text
+        x="530"
+        y="164"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-2)"
+      >
+        {"Engineer \u00B7 Designer \u00B7 Researcher"}
+      </text>
+
+      {/* Product A spoke */}
+      <rect
+        x="398"
+        y="234"
+        width="80"
+        height="40"
+        rx="6"
+        fill="var(--color-surface)"
+        stroke="var(--color-border-subtle)"
+        strokeWidth="1"
+      />
+      <text
+        x="438"
+        y="258"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        Product A
+      </text>
+
+      {/* Product B spoke */}
+      <rect
+        x="490"
+        y="234"
+        width="80"
+        height="40"
+        rx="6"
+        fill="var(--color-surface)"
+        stroke="var(--color-border-subtle)"
+        strokeWidth="1"
+      />
+      <text
+        x="530"
+        y="258"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        Product B
+      </text>
+
+      {/* Product C spoke */}
+      <rect
+        x="582"
+        y="234"
+        width="80"
+        height="40"
+        rx="6"
+        fill="var(--color-surface)"
+        stroke="var(--color-border-subtle)"
+        strokeWidth="1"
+      />
+      <text
+        x="622"
+        y="258"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        Product C
+      </text>
+
+      {/* Connecting lines from hub to spokes */}
+      <line
+        x1="490"
+        y1="190"
+        x2="438"
+        y2="234"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+        opacity="0.5"
+      />
+      <line
+        x1="530"
+        y1="190"
+        x2="530"
+        y2="234"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+        opacity="0.5"
+      />
+      <line
+        x1="570"
+        y1="190"
+        x2="622"
+        y2="234"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+        opacity="0.5"
+      />
+
+      {/* Hub-and-spoke annotation */}
+      <text
+        x="530"
+        y="298"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontStyle="italic"
+        fill="var(--color-accent)"
+      >
+        Hub-and-spoke model
+      </text>
+
+      {/* Shared process highlight */}
+      <text
+        x="530"
+        y="332"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        Shared components, design tokens, and process
+      </text>
+    </svg>
+  );
+}

--- a/app/case-studies/components/diagrams/VenuePageArchitecture.tsx
+++ b/app/case-studies/components/diagrams/VenuePageArchitecture.tsx
@@ -1,0 +1,280 @@
+export default function VenuePageArchitecture() {
+  return (
+    <svg
+      viewBox="0 0 600 400"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Venue page component architecture diagram showing SearchFilters at the top flowing into MapView and ResultsList branches, connected by a shared GraphQL data layer with URL-synced filter state"
+    >
+      <defs>
+        <marker
+          id="arrowhead"
+          markerWidth="8"
+          markerHeight="6"
+          refX="8"
+          refY="3"
+          orient="auto"
+        >
+          <path
+            d="M0,0 L8,3 L0,6"
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth="1.5"
+          />
+        </marker>
+        <marker
+          id="arrowhead-dashed"
+          markerWidth="8"
+          markerHeight="6"
+          refX="8"
+          refY="3"
+          orient="auto"
+        >
+          <path
+            d="M0,0 L8,3 L0,6"
+            fill="none"
+            stroke="var(--color-text-muted)"
+            strokeWidth="1.5"
+          />
+        </marker>
+      </defs>
+
+      {/* SearchFilters — top-level box */}
+      <rect
+        x="100"
+        y="24"
+        width="400"
+        height="56"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      <text
+        x="300"
+        y="50"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="15"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        SearchFilters
+      </text>
+      <text
+        x="300"
+        y="68"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        URL-driven query params
+      </text>
+
+      {/* Center vertical line from SearchFilters */}
+      <line
+        x1="300"
+        y1="80"
+        x2="300"
+        y2="120"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+      />
+
+      {/* Split point dot */}
+      <circle cx="300" cy="120" r="3" fill="var(--color-accent)" />
+
+      {/* Left branch — dashed line to MapView */}
+      <line
+        x1="300"
+        y1="120"
+        x2="175"
+        y2="120"
+        stroke="var(--color-text-muted)"
+        strokeWidth="1.5"
+        strokeDasharray="6 4"
+      />
+      <line
+        x1="175"
+        y1="120"
+        x2="175"
+        y2="160"
+        stroke="var(--color-text-muted)"
+        strokeWidth="1.5"
+        strokeDasharray="6 4"
+        markerEnd="url(#arrowhead-dashed)"
+      />
+
+      {/* Right branch — solid line to ResultsList */}
+      <line
+        x1="300"
+        y1="120"
+        x2="425"
+        y2="120"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+      />
+      <line
+        x1="425"
+        y1="120"
+        x2="425"
+        y2="160"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        markerEnd="url(#arrowhead)"
+      />
+
+      {/* MapView box */}
+      <rect
+        x="75"
+        y="168"
+        width="200"
+        height="64"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-text-muted)"
+        strokeWidth="1"
+        strokeDasharray="6 4"
+      />
+      <text
+        x="175"
+        y="196"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="14"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        MapView
+      </text>
+      <text
+        x="175"
+        y="216"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontStyle="italic"
+        fill="var(--color-text-muted)"
+      >
+        (lazy loaded)
+      </text>
+
+      {/* ResultsList box */}
+      <rect
+        x="325"
+        y="168"
+        width="200"
+        height="64"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+      />
+      <text
+        x="425"
+        y="196"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="14"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        ResultsList
+      </text>
+      <text
+        x="425"
+        y="216"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontStyle="italic"
+        fill="var(--color-accent)"
+      >
+        (optimistic UI)
+      </text>
+
+      {/* Horizontal connector between the two boxes */}
+      <line
+        x1="175"
+        y1="256"
+        x2="175"
+        y2="272"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <line
+        x1="425"
+        y1="256"
+        x2="425"
+        y2="272"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <line
+        x1="175"
+        y1="272"
+        x2="425"
+        y2="272"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+
+      {/* Arrow down to GraphQL layer */}
+      <line
+        x1="300"
+        y1="272"
+        x2="300"
+        y2="304"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        markerEnd="url(#arrowhead)"
+      />
+
+      {/* GraphQL Data Layer box */}
+      <rect
+        x="100"
+        y="312"
+        width="400"
+        height="64"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      {/* Subtle glow effect */}
+      <rect
+        x="100"
+        y="312"
+        width="400"
+        height="64"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="4"
+        opacity="0.3"
+      />
+      <text
+        x="300"
+        y="340"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="15"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        GraphQL Data Layer
+      </text>
+      <text
+        x="300"
+        y="360"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-2)"
+      >
+        URL-synced Filter State
+      </text>
+    </svg>
+  );
+}

--- a/app/case-studies/data.ts
+++ b/app/case-studies/data.ts
@@ -1,0 +1,131 @@
+export type CaseStudyMetric = {
+  value: string;
+  label: string;
+};
+
+export type CaseStudySection = {
+  heading: string;
+  content: string[];
+};
+
+export type CaseStudy = {
+  slug: string;
+  title: string;
+  subtitle: string;
+  company: string;
+  companyLink: string;
+  period: string;
+  role: string;
+  teaserDescription: string;
+  metrics: CaseStudyMetric[];
+  sections: CaseStudySection[];
+  tech: string[];
+  diagramIds: string[];
+};
+
+export const CASE_STUDIES: CaseStudy[] = [
+  {
+    slug: "venue-page",
+    title: "Rewriting PartySlate\u2019s Most Impactful Page",
+    subtitle: "How a Find Venues rewrite drove a 150% increase in venue inquiries",
+    company: "PartySlate",
+    companyLink: "https://www.partyslate.com",
+    period: "2018\u20132024",
+    role: "Staff Frontend Engineer",
+    teaserDescription: "A ground-up rewrite of PartySlate\u2019s highest-traffic page \u2014 redesigned search, interactive map view, and a modernized React/GraphQL architecture that drove a 150% increase in venue inquiries.",
+    metrics: [
+      { value: "150%", label: "Increase in venue inquiries" },
+      { value: "78 \u2192 95", label: "Lighthouse accessibility score" },
+      { value: "-40%", label: "Bundle size reduction" },
+      { value: "-2.3s", label: "Page load improvement" },
+    ],
+    sections: [
+      {
+        heading: "Problem",
+        content: [
+          "PartySlate\u2019s Find Venues page was the single most impactful page on the platform \u2014 the front door for couples searching for event spaces. But inquiry volume had plateaued despite steady traffic growth. The existing page was a static list with basic filters: slow to load, hard to browse, and missing the spatial context that venue search demands. Users were landing, scrolling, and leaving without converting.",
+          "The page also carried years of accumulated technical debt. The component was monolithic, tightly coupled to a legacy data-fetching layer, and nearly impossible to iterate on without risking regressions across the marketplace.",
+        ],
+      },
+      {
+        heading: "Approach",
+        content: [
+          "Rather than patch the existing implementation, I advocated for a full rewrite \u2014 scoped tightly to the venue page to limit blast radius while proving out patterns the team could adopt elsewhere.",
+          "The core insight was that venue search is inherently spatial. Couples don\u2019t just want a list of venues \u2014 they want to understand where venues are relative to each other, to landmarks, to neighborhoods. I designed the new experience around an interactive map view paired with a redesigned search results panel, letting users toggle between map and list views while filters stay persistent.",
+          "I led the technical design and implementation end-to-end: component architecture, data layer, performance budget, and rollout plan. The team worked in two-week sprints, with feature-flagged releases so we could ship incrementally and measure impact at each stage.",
+        ],
+      },
+      {
+        heading: "Architecture",
+        content: [
+          "The rewrite introduced a clean component hierarchy: SearchFilters feeds both MapView and ResultsList through shared state, with a GraphQL data layer replacing the legacy REST calls. The GraphQL schema was designed for this page\u2019s specific query patterns \u2014 fetching venue cards with just the fields needed for list rendering, and a separate lighter query for map pins.",
+          "Shared filter state was lifted to a URL-synced context, so search state survives navigation and enables shareable links. The MapView component only loads when the user switches to map mode, keeping the default list view fast. Filter changes use optimistic UI \u2014 results update immediately with cached data while the network request resolves.",
+          "An image optimization pipeline with responsive srcsets and blur placeholders cut largest contentful paint significantly. Code splitting and tree-shaking of legacy dependencies brought the bundle size down 40%.",
+        ],
+      },
+      {
+        heading: "Results",
+        content: [
+          "The rewrite shipped over six weeks and the numbers were immediate. Venue inquiries increased 150% within the first month, validating that the UX friction \u2014 not traffic \u2014 had been the bottleneck. Lighthouse accessibility climbed from 78 to 95 as we built WCAG 2.1 AA compliance into the component library rather than patching it after. Bundle size dropped 40% through code splitting and tree-shaking the legacy dependencies. Average page load time decreased by 2.3 seconds.",
+          "Beyond the metrics, the rewrite established patterns the team adopted across the platform: the shared-state filter architecture became the template for the vendor search and photo gallery pages, and the GraphQL data layer replaced REST calls over the following quarters.",
+        ],
+      },
+    ],
+    tech: ["React", "Next.js", "GraphQL", "TypeScript", "Chakra UI", "Storybook", "Lighthouse"],
+    diagramIds: ["venue-page-architecture", "metrics-before-after"],
+  },
+  {
+    slug: "design-system-leadership",
+    title: "Building a UX Practice from Scratch",
+    subtitle: "Spinning out an autonomous team, running 50+ research sessions, and creating a living design system",
+    company: "Savo",
+    companyLink: "https://pitchbook.com/profiles/company/13234-69#overview",
+    period: "2013\u20132018",
+    role: "Senior Product Developer",
+    teaserDescription: "Led the creation of Savo\u2019s first dedicated UX practice \u2014 from spinning out an autonomous team to running 50+ research sessions and building a living design system that unified product development across Salesforce integrations.",
+    metrics: [
+      { value: "50+", label: "User research sessions" },
+      { value: "30%", label: "Increase in user satisfaction" },
+      { value: "20%", label: "Developer productivity improvement" },
+      { value: "1st", label: "Living design system at Savo" },
+    ],
+    sections: [
+      {
+        heading: "Problem",
+        content: [
+          "When I joined Savo, there was no dedicated UX practice. Designers were embedded in product teams with no shared process, no research cadence, and no design system. The result was visible: three separate products with inconsistent interfaces, duplicated components, and UX decisions driven by stakeholder opinion rather than user evidence.",
+          "The technical challenge compounded the organizational one. Savo\u2019s platform needed to work seamlessly inside Salesforce \u2014 a complex integration environment where UI components had to coexist with Salesforce\u2019s own styling, respect its security model, and render inside iframes and Lightning containers. Every product team was solving these integration problems independently, often reaching different conclusions.",
+        ],
+      },
+      {
+        heading: "Approach",
+        content: [
+          "I saw an opportunity to address both problems simultaneously. The fragmented UX wasn\u2019t just a design problem \u2014 it was an engineering architecture problem. If we built the right component infrastructure, we could enforce consistency while making individual teams faster.",
+          "I championed spinning out a dedicated UI/UX team: a small, autonomous group with a mandate to establish research practices, define design standards, and build shared tooling. The team included myself, a UX designer, and a UX researcher. We reported to the VP of Product, which gave us the organizational leverage to work across all product teams.",
+          "We started with research. Over the next two years, I planned and facilitated 50+ sessions: usability interviews, design workshops, stakeholder alignment meetings, and field studies with enterprise sales teams using the product in their Salesforce workflows. The research didn\u2019t just inform design \u2014 it built organizational credibility. When product managers saw us testing their assumptions with real users, they started coming to us proactively.",
+        ],
+      },
+      {
+        heading: "Architecture",
+        content: [
+          "The design system was built in Ember.js on top of Material Design \u2014 providing familiar visual language while customizing for Savo\u2019s specific needs. The system had three layers:",
+          "The foundation layer adapted Material Design tokens for Savo\u2019s brand: color, typography, spacing, and elevation. The component layer implemented the design language in Ember.js with built-in Salesforce compatibility: iframe-safe styling, Lightning-aware event handling, and responsive layouts that work within Salesforce\u2019s panel constraints. The integration layer handled the Salesforce embedding lifecycle: authentication handshakes, cross-origin communication, and state synchronization between the Savo UI and the surrounding Salesforce context.",
+          "To ensure adoption, I established the Front-End Guild \u2014 a bi-weekly meeting open to all developers covering front-end fundamentals, design system usage, and industry trends. The guild served dual purposes: it was an education channel that lowered the barrier to contributing components, and a feedback loop that surfaced friction in the design system APIs. I also authored the contribution guidelines and documentation, making it clear how teams could consume existing components, propose new ones, and extend the system without fragmenting it.",
+        ],
+      },
+      {
+        heading: "Results",
+        content: [
+          "User satisfaction increased 30% \u2014 measured through quarterly NPS surveys that the research practice itself had established. Developer productivity improved 20%, measured by sprint velocity across teams using the design system versus the baseline period. More importantly, the organizational shift stuck: the UX team continued to grow after I left, and the research-driven process became how Savo made product decisions.",
+          "The design system became the single source of truth for UI development across all Savo products, including the Salesforce integrations. New features that previously required 2\u20133 weeks of Salesforce-specific UI work could be assembled from existing components in days. The Front-End Guild ran for years and became a template for similar engineering guilds at the company.",
+        ],
+      },
+    ],
+    tech: ["Ember.js", "Material Design", "Salesforce Lightning", "SCSS", "Agile/Lean UX"],
+    diagramIds: ["team-structure", "design-system-layers"],
+  },
+];
+
+export function getCaseStudyBySlug(slug: string): CaseStudy | undefined {
+  return CASE_STUDIES.find((cs) => cs.slug === slug);
+}

--- a/app/case-studies/style.css
+++ b/app/case-studies/style.css
@@ -1,0 +1,217 @@
+/* ===========================================
+   CASE STUDY DETAIL PAGE
+   =========================================== */
+
+/* Hero */
+.cs-hero {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 120px 1.5rem 3rem;
+  text-align: center;
+}
+
+.cs-hero-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  border-left: 2px solid var(--color-primary);
+  padding-left: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.cs-hero-meta-separator {
+  color: var(--color-border);
+  user-select: none;
+}
+
+.cs-hero-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--color-text);
+  margin: 0 0 1.5rem;
+}
+
+.cs-hero-subtitle {
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+  margin: 0;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Metrics bar */
+.cs-metrics-bar {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+  max-width: 720px;
+  margin: 0 auto 3rem;
+  padding: 2rem;
+}
+
+.cs-metric {
+  text-align: center;
+  flex: 1;
+  min-width: 120px;
+}
+
+.cs-metric-value {
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1.2;
+}
+
+.cs-metric-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin-top: 0.25rem;
+}
+
+/* Body container */
+.cs-body {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+/* Section headings */
+.cs-section-heading {
+  font-family: var(--font-display);
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  padding-left: 1rem;
+  border-left: 2px solid var(--color-primary);
+  margin: 3rem 0 1.5rem;
+}
+
+/* Diagram wrapper */
+.cs-diagram-wrapper {
+  padding: 2rem;
+  margin: 2rem 0;
+}
+
+.cs-diagram-wrapper figure {
+  margin: 0;
+}
+
+.cs-diagram-caption {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  text-align: center;
+  margin-top: 1rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.05em;
+}
+
+/* Tech section */
+.cs-tech {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.cs-tech-label {
+  font-family: var(--font-display);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-bottom: 1rem;
+}
+
+.cs-tech-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+/* Navigation footer */
+.cs-nav {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.cs-nav-card {
+  padding: 1.5rem;
+  text-decoration: none;
+  display: block;
+  transition: all 0.3s ease;
+}
+
+.cs-nav-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.cs-nav-title {
+  font-family: var(--font-display);
+  color: var(--color-text);
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.cs-nav-home {
+  grid-column: 1 / -1;
+  text-align: center;
+}
+
+/* Mobile */
+@media (max-width: 640px) {
+  .cs-hero {
+    padding-top: 100px;
+  }
+
+  .cs-metrics-bar {
+    gap: 1rem;
+  }
+
+  .cs-metric {
+    min-width: 100px;
+  }
+
+  .cs-nav {
+    grid-template-columns: 1fr;
+  }
+
+  .cs-diagram-wrapper {
+    padding: 1rem;
+  }
+
+  .cs-hero-meta {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+}

--- a/app/components/CaseStudies.css
+++ b/app/components/CaseStudies.css
@@ -1,0 +1,79 @@
+/* Case study teaser card layout */
+.case-study-card {
+  padding: 1.5rem;
+}
+
+/* Title styling - display font */
+.case-study-title {
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 500;
+  color: var(--color-text);
+  line-height: 1.3;
+}
+
+/* Metrics row - horizontal flex with top border */
+.case-study-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+/* Individual metric block */
+.case-study-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+/* Metric value - large number in primary color (body font for clean numerals) */
+.case-study-metric-value {
+  font-family: var(--font-body);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  line-height: 1.2;
+}
+
+/* Metric label - small uppercase muted text */
+.case-study-metric-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-2);
+  line-height: 1.4;
+}
+
+/* Read case study link */
+.case-study-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-display);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: gap 0.2s ease;
+}
+
+.case-study-link:hover {
+  gap: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 767px) {
+  .case-study-card {
+    padding: 1.25rem;
+  }
+
+  .case-study-metrics {
+    gap: 1.25rem;
+  }
+
+  .case-study-metric-value {
+    font-size: 1.25rem;
+  }
+}

--- a/app/components/CaseStudies.tsx
+++ b/app/components/CaseStudies.tsx
@@ -1,0 +1,60 @@
+import { Box, Container, Flex, Heading, Text } from "@radix-ui/themes";
+import Link from "next/link";
+import AnimatedSection from "./AnimatedSection";
+import { CASE_STUDIES } from "../case-studies/data";
+import "./CaseStudies.css";
+
+export default function CaseStudies() {
+  return (
+    <Box id="case-studies" py="9" style={{ background: "var(--gradient-section)", position: "relative", overflow: "hidden" }}>
+      <AnimatedSection style={{ position: "relative", zIndex: 1 }}>
+        <Container size="4" px="6">
+          {/* Asymmetric grid layout */}
+          <Flex direction={{ initial: "column", md: "row" }} gap={{ initial: "4", md: "8" }} align="start">
+            {/* Left column - Section header */}
+            <Box className="section-header-column">
+              <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
+                Impact
+              </Text>
+              <Heading size="8" className="section-title" style={{ textAlign: "left" }}>
+                Case Studies
+              </Heading>
+            </Box>
+
+            {/* Right column - Teaser cards */}
+            <Flex direction="column" gap="5" style={{ flex: 1 }}>
+              {CASE_STUDIES.map((study) => (
+                <Box key={study.slug} className="card case-study-card">
+                  <Text className="date-badge" mb="3" style={{ display: "block" }}>
+                    {study.period} &middot; {study.company}
+                  </Text>
+
+                  <Text className="case-study-title" mb="3" style={{ display: "block" }}>
+                    {study.title}
+                  </Text>
+
+                  <Text className="about-narrative" mb="4" style={{ display: "block" }}>
+                    {study.teaserDescription}
+                  </Text>
+
+                  <Flex className="case-study-metrics" mb="4">
+                    {study.metrics.slice(0, 3).map((metric, i) => (
+                      <Box key={i} className="case-study-metric">
+                        <Text className="case-study-metric-value">{metric.value}</Text>
+                        <Text className="case-study-metric-label">{metric.label}</Text>
+                      </Box>
+                    ))}
+                  </Flex>
+
+                  <Link href={`/case-studies/${study.slug}`} className="case-study-link">
+                    Read case study <span aria-hidden="true">&rarr;</span>
+                  </Link>
+                </Box>
+              ))}
+            </Flex>
+          </Flex>
+        </Container>
+      </AnimatedSection>
+    </Box>
+  );
+}

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -17,6 +17,7 @@ const HOME_LINKS = [
   { href: "#about", label: "About" },
   { href: "#skills", label: "Skills" },
   { href: "#experience", label: "Experience" },
+  { href: "#case-studies", label: "Case Studies" },
   { href: "#projects", label: "Projects" },
 ];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import StatsBar from "./components/StatsBar";
 import About from "./components/About";
 import Skills from "./components/Skills";
 import Experience from "./components/Experience";
+import CaseStudies from "./components/CaseStudies";
 import Projects from "./components/Projects";
 import Footer from "./components/Footer";
 
@@ -17,6 +18,7 @@ export default function Home() {
       <About />
       <Skills />
       <Experience />
+      <CaseStudies />
       <Projects />
       <Footer />
     </Box>

--- a/docs/plans/portfolio-redesign.md
+++ b/docs/plans/portfolio-redesign.md
@@ -65,17 +65,28 @@ Each phase is independently plannable. After completing a phase, update the "Pha
 ---
 
 ### Phase 3: Case Studies
-**Status:** `pending`
-**Goal:** Add 1-2 detailed case studies that prove staff-level work with visuals, architecture decisions, and measurable outcomes.
+**Status:** `completed`
+**Branch:** `phase3-case-studies`
+**Goal:** Add 2 detailed case studies that prove staff-level work with code-generated diagrams, architecture decisions, and measurable outcomes.
 
 **Scope:**
-- PartySlate Venue Page rewrite (primary candidate: 150% inquiry increase, map-view, search redesign)
-- Potentially: Design system / component library work at PartySlate or Savo
-- Format: problem statement, approach, architecture, screenshots/mockups, results
-- May require a new route (`/case-studies/[slug]`) or in-page expandable sections
-- Source screenshots and visual assets
+- PartySlate Venue Page rewrite (150% inquiry increase, map-view, search redesign, Lighthouse 78→95)
+- Savo Design System Leadership (UX team spinout, 50+ research sessions, living design system)
+- Format: problem → approach → architecture → results with inline SVG diagrams
+- Standalone pages at `/case-studies/[slug]` with SSG + metadata
+- Homepage teaser section between Experience and Projects
+- 4 SVG diagram components (server-rendered, CSS variable themed)
 
-**Learnings:** _(updated after completion)_
+**Learnings:**
+- Two case studies cover both pillars of staff-level work: technical depth (PartySlate) and organizational influence (Savo).
+- Code-generated SVG diagrams avoid the need for product screenshots (none available). Using CSS variables makes them theme-consistent.
+- Content in TypeScript data files (not MDX) — consistent with Phase 1 decision to remove MDX. The `data.ts` + `getCaseStudyBySlug()` pattern mirrors `app/art/images.ts`.
+- Copy was drafted collaboratively (presented for review before implementation), matching the Phase 2 workflow.
+- Detail pages use single-column editorial layout (720px max-width) for focused reading, unlike the asymmetric grid used on the homepage.
+- Homepage teaser uses the asymmetric grid pattern (section-header-column left, content right) consistent with About/Skills/Projects.
+- Diagrams are server components with `viewBox` for responsive scaling, `role="img"` + `aria-label` for accessibility.
+- DiagramRenderer component maps string IDs to diagram components with figcaption support.
+- 11 new files, 3 modified files. Clean build with both slugs in static params.
 
 ---
 


### PR DESCRIPTION
## Summary
- Two detailed case study pages at `/case-studies/venue-page` and `/case-studies/design-system-leadership` with SSG, metadata, and 404 handling
- 4 inline SVG diagram components (VenuePageArchitecture, MetricsBeforeAfter, TeamStructure, DesignSystemLayers) using CSS variables and aria-labels
- Homepage teaser section between Experience and Projects with asymmetric grid, metric highlights, and "Read case study →" links
- "Case Studies" nav link added to header
- Phase 3 marked complete in redesign plan

## New files (11)
| File | Purpose |
|------|---------|
| `app/case-studies/data.ts` | Types + content data |
| `app/case-studies/[slug]/page.tsx` | Detail page route (SSG + metadata) |
| `app/case-studies/style.css` | Detail page CSS |
| `app/case-studies/components/CaseStudyContent.tsx` | Detail page renderer |
| `app/case-studies/components/DiagramRenderer.tsx` | Diagram ID → component mapper |
| `app/case-studies/components/diagrams/*.tsx` | 4 SVG diagram components |
| `app/components/CaseStudies.tsx` | Homepage teaser section |
| `app/components/CaseStudies.css` | Homepage teaser CSS |

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean, both slugs in static params
- [ ] Homepage: Case Studies section appears between Experience and Projects
- [ ] Nav: "Case Studies" link scrolls to section
- [ ] `/case-studies/venue-page` renders correctly with diagrams
- [ ] `/case-studies/design-system-leadership` renders correctly with diagrams
- [ ] `/case-studies/nonexistent` returns 404
- [ ] Mobile: responsive at 375px and 768px

🤖 Generated with [Claude Code](https://claude.com/claude-code)