### PR TITLE
feat(projects): overhaul Projects section with SVG diagrams

### DIFF
--- a/app/components/Projects/diagrams/ClaudeSkillsPipeline.tsx
+++ b/app/components/Projects/diagrams/ClaudeSkillsPipeline.tsx
@@ -1,0 +1,403 @@
+export default function ClaudeSkillsPipeline() {
+  return (
+    <svg
+      viewBox="0 0 600 260"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Claude Skills pipeline diagram showing Claude Code on the left connecting via MCP to six skills (hydrate, remember, recall, reflect, glean, pickup) in the center, which persist to an Obsidian Vault on the right"
+    >
+      <defs>
+        <marker
+          id="cs-arrow"
+          markerWidth="8"
+          markerHeight="6"
+          refX="8"
+          refY="3"
+          orient="auto"
+        >
+          <path
+            d="M0,0 L8,3 L0,6"
+            fill="none"
+            stroke="var(--color-primary)"
+            strokeWidth="1.5"
+          />
+        </marker>
+      </defs>
+
+      {/* ========== CLAUDE CODE (left) ========== */}
+      <rect
+        x="16"
+        y="80"
+        width="108"
+        height="64"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      {/* Subtle glow */}
+      <rect
+        x="16"
+        y="80"
+        width="108"
+        height="64"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="6"
+        opacity="0.2"
+      />
+      <text
+        x="70"
+        y="108"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="600"
+        fill="var(--color-text)"
+      >
+        Claude Code
+      </text>
+      <text
+        x="70"
+        y="124"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="9"
+        fill="var(--color-text-muted)"
+      >
+        AI Agent
+      </text>
+
+      {/* ========== CONNECTING LINE: Claude Code → Skills ========== */}
+      <line
+        x1="124"
+        y1="112"
+        x2="186"
+        y2="112"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+        markerEnd="url(#cs-arrow)"
+      />
+
+      {/* MCP label on the connecting line */}
+      <rect
+        x="136"
+        y="94"
+        width="36"
+        height="14"
+        rx="3"
+        fill="var(--color-surface)"
+        stroke="var(--color-border)"
+        strokeWidth="0.75"
+      />
+      <text
+        x="154"
+        y="104"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="8"
+        fontWeight="500"
+        letterSpacing="0.06em"
+        fill="var(--color-accent)"
+      >
+        MCP
+      </text>
+
+      {/* ========== SKILLS GRID (center, 2 rows x 3 cols) ========== */}
+
+      {/* Skills container outline */}
+      <rect
+        x="192"
+        y="44"
+        width="216"
+        height="176"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+        strokeDasharray="4 3"
+      />
+      <text
+        x="300"
+        y="62"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="10"
+        fontWeight="500"
+        letterSpacing="0.1em"
+        fill="var(--color-text-muted)"
+      >
+        SKILLS
+      </text>
+
+      {/* Row 1: hydrate, remember, recall */}
+      {/* hydrate */}
+      <rect
+        x="202"
+        y="74"
+        width="60"
+        height="32"
+        rx="6"
+        fill="var(--color-elevated)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="232"
+        y="94"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        hydrate
+      </text>
+
+      {/* remember */}
+      <rect
+        x="270"
+        y="74"
+        width="60"
+        height="32"
+        rx="6"
+        fill="var(--color-elevated)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="300"
+        y="94"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        remember
+      </text>
+
+      {/* recall */}
+      <rect
+        x="338"
+        y="74"
+        width="60"
+        height="32"
+        rx="6"
+        fill="var(--color-elevated)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="368"
+        y="94"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        recall
+      </text>
+
+      {/* Row 2: reflect, glean, pickup */}
+      {/* reflect */}
+      <rect
+        x="202"
+        y="116"
+        width="60"
+        height="32"
+        rx="6"
+        fill="var(--color-elevated)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="232"
+        y="136"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        reflect
+      </text>
+
+      {/* glean */}
+      <rect
+        x="270"
+        y="116"
+        width="60"
+        height="32"
+        rx="6"
+        fill="var(--color-elevated)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="300"
+        y="136"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        glean
+      </text>
+
+      {/* pickup */}
+      <rect
+        x="338"
+        y="116"
+        width="60"
+        height="32"
+        rx="6"
+        fill="var(--color-elevated)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <text
+        x="368"
+        y="136"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-2)"
+      >
+        pickup
+      </text>
+
+      {/* Annotation under skills */}
+      <text
+        x="300"
+        y="170"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="9"
+        fontStyle="italic"
+        fill="var(--color-text-muted)"
+      >
+        Cross-session memory tools
+      </text>
+
+      {/* Flow direction labels */}
+      <text
+        x="247"
+        y="200"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="8"
+        fill="var(--color-text-muted)"
+      >
+        {"read \u2190"}
+      </text>
+      <text
+        x="353"
+        y="200"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="8"
+        fill="var(--color-text-muted)"
+      >
+        {"\u2192 write"}
+      </text>
+
+      {/* ========== CONNECTING LINE: Skills → Obsidian ========== */}
+      <line
+        x1="408"
+        y1="112"
+        x2="470"
+        y2="112"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+        markerEnd="url(#cs-arrow)"
+      />
+
+      {/* MCP label on the right connecting line */}
+      <rect
+        x="420"
+        y="94"
+        width="36"
+        height="14"
+        rx="3"
+        fill="var(--color-surface)"
+        stroke="var(--color-border)"
+        strokeWidth="0.75"
+      />
+      <text
+        x="438"
+        y="104"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="8"
+        fontWeight="500"
+        letterSpacing="0.06em"
+        fill="var(--color-accent)"
+      >
+        MCP
+      </text>
+
+      {/* ========== OBSIDIAN VAULT (right) ========== */}
+      <rect
+        x="476"
+        y="80"
+        width="108"
+        height="64"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      {/* Subtle glow */}
+      <rect
+        x="476"
+        y="80"
+        width="108"
+        height="64"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="6"
+        opacity="0.2"
+      />
+      <text
+        x="530"
+        y="108"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="600"
+        fill="var(--color-text)"
+      >
+        Obsidian Vault
+      </text>
+      <text
+        x="530"
+        y="124"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="9"
+        fill="var(--color-text-muted)"
+      >
+        Markdown files
+      </text>
+
+      {/* ========== BOTTOM ANNOTATION ========== */}
+      <text
+        x="300"
+        y="248"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontStyle="italic"
+        fill="var(--color-accent)"
+      >
+        Persistent memory across Claude Code sessions
+      </text>
+    </svg>
+  );
+}

--- a/app/components/Projects/diagrams/WavePointArchitecture.tsx
+++ b/app/components/Projects/diagrams/WavePointArchitecture.tsx
@@ -1,0 +1,356 @@
+export default function WavePointArchitecture() {
+  return (
+    <svg
+      viewBox="0 0 600 280"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="WavePoint monorepo architecture diagram showing shared TypeScript and Swift packages feeding a Next.js web app and six native Apple apps built with SwiftUI, all connected to shared Supabase Auth, Stripe Payments, and Brevo CRM services"
+    >
+      <defs>
+        <marker
+          id="wp-arrow"
+          markerWidth="8"
+          markerHeight="6"
+          refX="8"
+          refY="3"
+          orient="auto"
+        >
+          <path
+            d="M0,0 L8,3 L0,6"
+            fill="none"
+            stroke="var(--color-accent)"
+            strokeWidth="1.5"
+          />
+        </marker>
+      </defs>
+
+      {/* Monorepo container */}
+      <rect
+        x="20"
+        y="8"
+        width="560"
+        height="220"
+        rx="8"
+        fill="none"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+        strokeDasharray="6 4"
+      />
+      <text
+        x="40"
+        y="26"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fontWeight="500"
+        fill="var(--color-text-muted)"
+      >
+        Monorepo
+      </text>
+
+      {/* Shared Packages layer */}
+      {/* @wavepoint/content (TypeScript) */}
+      <rect
+        x="80"
+        y="38"
+        width="200"
+        height="48"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      <rect
+        x="80"
+        y="38"
+        width="200"
+        height="48"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="4"
+        opacity="0.3"
+      />
+      <text
+        x="180"
+        y="60"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        @wavepoint/content
+      </text>
+      <text
+        x="180"
+        y="76"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        TypeScript
+      </text>
+
+      {/* WavePointCore (Swift) */}
+      <rect
+        x="320"
+        y="38"
+        width="200"
+        height="48"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      <rect
+        x="320"
+        y="38"
+        width="200"
+        height="48"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="4"
+        opacity="0.3"
+      />
+      <text
+        x="420"
+        y="60"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="13"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        WavePointCore
+      </text>
+      <text
+        x="420"
+        y="76"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-muted)"
+      >
+        Swift Package
+      </text>
+
+      {/* Connecting lines from shared packages to app branches */}
+      {/* Left line from @wavepoint/content down to Next.js */}
+      <line
+        x1="180"
+        y1="86"
+        x2="180"
+        y2="128"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        markerEnd="url(#wp-arrow)"
+      />
+
+      {/* Right line from WavePointCore down to Native Apps */}
+      <line
+        x1="420"
+        y1="86"
+        x2="420"
+        y2="128"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        markerEnd="url(#wp-arrow)"
+      />
+
+      {/* Cross-connect: @wavepoint/content to Native Apps */}
+      <line
+        x1="280"
+        y1="62"
+        x2="320"
+        y2="62"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+        strokeDasharray="4 3"
+      />
+
+      {/* Next.js Web App box */}
+      <rect
+        x="60"
+        y="136"
+        width="240"
+        height="48"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+      />
+      <text
+        x="180"
+        y="158"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="14"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Next.js Web App
+      </text>
+      <text
+        x="180"
+        y="174"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-2)"
+      >
+        React + TypeScript
+      </text>
+
+      {/* Native Apps box */}
+      <rect
+        x="340"
+        y="136"
+        width="200"
+        height="48"
+        rx="8"
+        fill="var(--color-surface)"
+        stroke="var(--color-primary)"
+        strokeWidth="1"
+      />
+      <text
+        x="440"
+        y="158"
+        textAnchor="middle"
+        fontFamily="var(--font-display)"
+        fontSize="14"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Native Apps
+      </text>
+      <text
+        x="440"
+        y="174"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="10"
+        fill="var(--color-text-2)"
+      >
+        iOS, macOS, iPadOS &middot; SwiftUI
+      </text>
+
+      {/* Connector lines from app boxes down to shared services */}
+      <line
+        x1="180"
+        y1="184"
+        x2="180"
+        y2="200"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <line
+        x1="440"
+        y1="184"
+        x2="440"
+        y2="200"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      {/* Horizontal bar connecting both down-lines */}
+      <line
+        x1="180"
+        y1="200"
+        x2="440"
+        y2="200"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      {/* Center drop to services bar */}
+      <line
+        x1="300"
+        y1="200"
+        x2="300"
+        y2="216"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        markerEnd="url(#wp-arrow)"
+      />
+
+      {/* Shared Services bar */}
+      <rect
+        x="60"
+        y="224"
+        width="480"
+        height="40"
+        rx="8"
+        fill="var(--color-elevated)"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+      />
+      <rect
+        x="60"
+        y="224"
+        width="480"
+        height="40"
+        rx="8"
+        fill="none"
+        stroke="var(--color-primary-glow)"
+        strokeWidth="4"
+        opacity="0.2"
+      />
+
+      {/* Service labels */}
+      <text
+        x="180"
+        y="248"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="11"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Supabase Auth
+      </text>
+      {/* Divider dots */}
+      <text
+        x="250"
+        y="248"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="11"
+        fill="var(--color-text-muted)"
+      >
+        &middot;
+      </text>
+      <text
+        x="320"
+        y="248"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="11"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Stripe Payments
+      </text>
+      <text
+        x="390"
+        y="248"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="11"
+        fill="var(--color-text-muted)"
+      >
+        &middot;
+      </text>
+      <text
+        x="460"
+        y="248"
+        textAnchor="middle"
+        fontFamily="var(--font-body)"
+        fontSize="11"
+        fontWeight="500"
+        fill="var(--color-text)"
+      >
+        Brevo CRM
+      </text>
+    </svg>
+  );
+}

--- a/app/components/Projects/index.tsx
+++ b/app/components/Projects/index.tsx
@@ -1,9 +1,31 @@
 import { Badge, Box, Button, Callout, Container, Flex, Heading, Link, Text } from "@radix-ui/themes";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
-import AnimatedSection from "./AnimatedSection";
-import "./Projects.css";
+import AnimatedSection from "../AnimatedSection";
+import WavePointArchitecture from "./diagrams/WavePointArchitecture";
+import ClaudeSkillsPipeline from "./diagrams/ClaudeSkillsPipeline";
+import "./style.css";
 
-const PROJECTS = [
+const DIAGRAMS: Record<string, React.ComponentType> = {
+  "wavepoint-architecture": WavePointArchitecture,
+  "claude-skills-pipeline": ClaudeSkillsPipeline,
+};
+
+type Project = {
+  title: string;
+  category: string;
+  callout: string | null;
+  githubLink: string | null;
+  liveLink: string | null;
+  liveLinkLabel?: string;
+  _target?: string;
+  description: string;
+  tech: string[];
+  gradientType: string;
+  featured?: boolean;
+  diagramId?: string;
+};
+
+const PROJECTS: Project[] = [
   {
     title: "WavePoint",
     category: "Platform",
@@ -11,35 +33,37 @@ const PROJECTS = [
     githubLink: null,
     liveLink: "https://wavepoint.space/",
     _target: "_blank",
-    description: "A cross-platform product shipping a Next.js web app and 6 native Apple apps from a single monorepo. Shared TypeScript content packages, a Swift astronomy engine for real-time calculations, Supabase auth, and Stripe payments \u2014 all coordinated across web, iOS, iPadOS, and macOS.",
+    description: "A cross-platform product shipping a Next.js web app and 6 native Apple apps from a single monorepo. Shared TypeScript content packages bridge web and native, a Swift astronomy engine powers real-time celestial calculations, and Supabase auth, Stripe payments, and Brevo CRM are coordinated across all platforms.",
     tech: [
-      "Next.js", "React", "TypeScript", "Supabase", "Stripe", "Swift", "SwiftUI"
+      "Next.js", "React", "TypeScript", "Supabase", "Stripe", "Brevo", "Swift", "SwiftUI"
     ],
     gradientType: "blue",
-    featured: true
+    featured: true,
+    diagramId: "wavepoint-architecture"
   },
   {
     title: "Claude Skills",
-    category: "Tool",
+    category: "Developer Tool",
     callout: null,
     githubLink: "https://github.com/robabby/claude-skills",
     liveLink: null,
     _target: "_blank",
-    description: "A cross-session memory system for Claude Code that uses Obsidian as persistent storage. Includes 6 skills for memory management: hydrate, remember, recall, reflect, glean, and pickup.",
+    description: "A cross-session memory and workflow system for Claude Code built on the MCP protocol. Six composable skills \u2014 hydrate, remember, recall, reflect, glean, and pickup \u2014 manage persistent state across conversations using Obsidian as the storage layer.",
     tech: ["Claude Code", "Obsidian", "MCP", "TypeScript"],
     gradientType: "purple",
-    featured: false
+    diagramId: "claude-skills-pipeline"
   },
   {
-    title: "AI Art Gallery",
-    category: "Gallery",
+    title: "robabby.com",
+    category: "Portfolio",
     callout: null,
     githubLink: "https://github.com/robabby/robabby",
     liveLink: "/art",
+    liveLinkLabel: "Art Gallery",
     _target: "_self",
-    description: "A smattering of AI-generated art pieces created using various tools including Midjourney, DALL·E 3, and Stable Diffusion. Showcased in a sleek, responsive Next.js application (this site).",
+    description: "A Next.js 15 + React 19 portfolio featuring code-generated SVG architecture diagrams, WCAG AA compliance, static generation with dynamic routes, motion/react animations with reduced-motion support, and an integrated AI art gallery with lightbox navigation.",
     tech: [
-      "Nextjs", "radix-ui", "Midjourney", "DALL-E", "Flux.1", "Invoke UI"
+      "Next.js", "React 19", "TypeScript", "Radix UI", "motion/react", "Vercel"
     ],
     gradientType: "gold"
   },
@@ -49,13 +73,13 @@ const PROJECTS = [
     callout: null,
     githubLink: "https://github.com/robabby/tldr-bot",
     liveLink: null,
-    description: "A Discord bot written in Python that leverages OpenAI's GPT-5 API to generate sarcastic summaries of recent messages in a channel. Will also generate memes based on message contents.",
+    description: "An early exploration of AI-powered developer tools \u2014 a Discord bot that uses OpenAI\u2019s API to generate sarcastic summaries of channel history and auto-generate memes from message context.",
     tech: [
       "Python", "Discord.py", "OpenAI GPT-5 API"
     ],
     gradientType: "green"
   }
-]
+];
 
 export default function Projects() {
 
@@ -72,7 +96,7 @@ export default function Projects() {
             {/* Left column - Section header */}
             <Box className="section-header-column">
               <Text className="section-subtitle" mb="2" style={{ display: "block" }}>
-                Work
+                Builds
               </Text>
               <Heading size="8" className="section-title" style={{ textAlign: "left" }}>
                 Projects
@@ -86,16 +110,30 @@ export default function Projects() {
                   key={index}
                   className={`card project-card ${proj.featured ? 'project-card--featured' : ''}`}
                 >
-                  <Box className={`project-visual project-visual--${proj.gradientType}`}>
-                    <Box className="project-visual-pattern" />
-                    <Box className="project-visual-content">
-                      <Badge size="1" className="badge--featured">
-                        {proj.category}
-                      </Badge>
-                      <Heading size="5" className="project-visual-title">{proj.title}</Heading>
-                    </Box>
+                  <Box className={`project-visual ${proj.diagramId ? 'project-visual--diagram' : `project-visual--${proj.gradientType}`}`}>
+                    {proj.diagramId && DIAGRAMS[proj.diagramId] ? (
+                      (() => {
+                        const DiagramComponent = DIAGRAMS[proj.diagramId!];
+                        return <DiagramComponent />;
+                      })()
+                    ) : (
+                      <Box className="project-visual-content">
+                        <Badge size="1" className="badge--featured">
+                          {proj.category}
+                        </Badge>
+                        <Heading size="5" className="project-visual-title">{proj.title}</Heading>
+                      </Box>
+                    )}
                   </Box>
                   <Box p="4">
+                    {proj.diagramId && (
+                      <Flex gap="2" align="center" mb="3">
+                        <Badge size="1" className="badge--featured">
+                          {proj.category}
+                        </Badge>
+                        <Heading size="4" style={{ color: "var(--color-text)" }}>{proj.title}</Heading>
+                      </Flex>
+                    )}
                     {proj.callout && (
                       <Callout.Root mb="3" size="1">
                         <Callout.Icon>
@@ -127,7 +165,7 @@ export default function Projects() {
                       {proj.liveLink && (
                         <Button size="1" asChild>
                           <Link href={proj.liveLink} target={proj._target}>
-                            Demo
+                            {proj.liveLinkLabel || "Demo"}
                           </Link>
                         </Button>
                       )}
@@ -142,4 +180,3 @@ export default function Projects() {
     </Box>
   )
 }
-

--- a/app/components/Projects/style.css
+++ b/app/components/Projects/style.css
@@ -19,20 +19,6 @@
     0 0 40px rgba(59, 130, 246, 0.2);
 }
 
-/* Primary gradient overlay for featured project visual */
-.project-card--featured .project-visual::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    135deg,
-    rgba(59, 130, 246, 0.1) 0%,
-    transparent 50%
-  );
-  pointer-events: none;
-  z-index: 1;
-}
-
 /* Mobile: single column */
 @media (max-width: 767px) {
   .projects-masonry {
@@ -47,39 +33,22 @@
 
 .project-visual {
   position: relative;
-  height: 120px;
+  height: 160px;
   overflow: hidden;
 }
 
 /* Featured project has taller visual */
 .project-card--featured .project-visual {
-  height: 160px;
+  height: 200px;
 }
 
-.project-visual--blue {
-  background: linear-gradient(
-    135deg,
-    rgba(59, 130, 246, 0.15) 0%,
-    rgba(59, 130, 246, 0.05) 50%,
-    rgba(30, 64, 120, 0.2) 100%
-  );
-}
-
+/* Gradient visuals for non-diagram cards */
 .project-visual--gold {
   background: linear-gradient(
     135deg,
     rgba(212, 184, 114, 0.15) 0%,
     rgba(212, 184, 114, 0.05) 50%,
     rgba(120, 100, 50, 0.2) 100%
-  );
-}
-
-.project-visual--purple {
-  background: linear-gradient(
-    135deg,
-    rgba(147, 112, 219, 0.15) 0%,
-    rgba(147, 112, 219, 0.05) 50%,
-    rgba(80, 60, 120, 0.2) 100%
   );
 }
 
@@ -92,19 +61,9 @@
   );
 }
 
-.project-visual-pattern {
-  position: absolute;
-  inset: 0;
-  background-image:
-    radial-gradient(circle at 20% 30%, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
-    radial-gradient(circle at 80% 70%, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
-    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.02) 2px, transparent 2px);
-  background-size: 40px 40px, 60px 60px, 80px 80px;
-  z-index: 1;
-}
-
-/* Bottom gradient scrim for text readability */
-.project-visual::before {
+/* Bottom gradient scrim for text readability on gradient cards */
+.project-visual--gold::before,
+.project-visual--green::before {
   content: '';
   position: absolute;
   bottom: 0;
@@ -151,7 +110,8 @@
 }
 
 /* Hover effect - subtle highlight overlay */
-.project-card:hover .project-visual::after {
+.project-card:hover .project-visual--gold::after,
+.project-card:hover .project-visual--green::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -161,4 +121,19 @@
     transparent 100%
   );
   pointer-events: none;
+}
+
+/* Diagram container for SVG project visuals */
+.project-visual--diagram {
+  background: var(--color-elevated);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 24px;
+}
+
+.project-visual--diagram svg {
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
 }

--- a/docs/plans/portfolio-redesign.md
+++ b/docs/plans/portfolio-redesign.md
@@ -91,16 +91,26 @@ Each phase is independently plannable. After completing a phase, update the "Pha
 ---
 
 ### Phase 4: Projects Section Overhaul
-**Status:** `pending`
-**Goal:** Replace hobby-level projects with evidence of staff-level engineering or reframe existing projects to highlight engineering depth.
+**Status:** `completed`
+**Branch:** `phase4-projects-overhaul`
+**Goal:** Elevate the Projects section from hobby-level cards with gradient placeholders to engineering-focused showcases with SVG diagrams and sharper descriptions.
 
 **Scope:**
-- Evaluate which current projects to keep, reframe, or remove
-- Add project screenshots/demos instead of gradient placeholder cards
-- Consider adding: design system work, architectural decision records, OSS contributions
-- Show the actual work — live embeds, video clips, or annotated screenshots
+- Rewrote all 4 project descriptions to emphasize engineering depth
+- Replaced AI Art Gallery card with robabby.com portfolio card (Art Gallery accessible via /art link)
+- Changed section subtitle from "Work" to "Builds"
+- Created 2 SVG architecture diagrams replacing gradient placeholders for top projects
+- Restructured Projects from flat files to directory format (matching Experience/ pattern)
+- Cleaned up CSS: removed unused gradient/pattern styles, increased visual heights
 
-**Learnings:** _(updated after completion)_
+**Learnings:**
+- Restructured `Projects.tsx` + `Projects.css` into `Projects/index.tsx` + `Projects/style.css` with `diagrams/` subdirectory, matching the `Experience/` directory pattern.
+- SVG diagrams for WavePoint (layered monorepo architecture) and Claude Skills (MCP pipeline flow) replace generic gradient headers, consistent with case study diagram approach from Phase 3.
+- Diagram rendering uses a `DIAGRAMS` lookup map keyed by `diagramId` field on the project type, keeping the conditional logic clean.
+- Cards with diagrams move the category badge + title below the visual into the card body; gradient-only cards keep the overlay title approach.
+- Removed 4 gradient classes (blue, purple, gold pattern, green pattern) and dot-pattern styles; kept only gold and green gradients for robabby.com and tldr-bot.
+- Copy was drafted collaboratively (presented for review before code), matching the Phase 2/3 workflow. WavePoint updated to include Brevo CRM integration.
+- 2 new SVG diagram files, 2 moved files, 1 modified plan file. Clean build and lint.
 
 ---
 


### PR DESCRIPTION
## Summary
- Restructured Projects from flat files to directory format (`Projects/index.tsx`, `Projects/style.css`, `Projects/diagrams/`)
- Created SVG architecture diagrams for WavePoint (monorepo layered view) and Claude Skills (MCP pipeline flow), replacing generic gradient placeholders
- Rewrote all 4 project descriptions for engineering depth; replaced AI Art Gallery card with robabby.com portfolio card
- Changed section subtitle from "Work" to "Builds"
- Cleaned up CSS: removed unused gradient/pattern styles, increased card visual heights, added diagram container styles

## Test plan
- [ ] `pnpm build` passes clean
- [ ] `pnpm lint` passes clean
- [ ] Homepage Projects section shows "Builds / Projects" subtitle
- [ ] WavePoint card displays SVG monorepo architecture diagram in header
- [ ] Claude Skills card displays SVG pipeline diagram in header
- [ ] robabby.com card links to GitHub + Art Gallery (/art, same tab)
- [ ] tldr-bot card renders with gradient visual
- [ ] Mobile: cards stack single column, diagrams scale responsively
- [ ] Nav: #projects anchor link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)