### PR TITLE
feat(projects): add Space-Viz project

### DIFF
--- a/app/components/Projects/index.tsx
+++ b/app/components/Projects/index.tsx
@@ -52,6 +52,19 @@ const PROJECTS: Project[] = [
     gradientType: "gold"
   },
   {
+    title: "Space-Viz",
+    category: "Utility",
+    callout: null,
+    githubLink: "https://github.com/robabby/space-viz",
+    liveLink: null,
+    _target: "_blank",
+    description: "A disk space visualization tool with interactive D3 sunburst and treemap charts. Scans directories recursively with block-level accuracy, supports drill-down navigation, and handles macOS APFS firmlinks and hidden files.",
+    tech: [
+      "Next.js 16", "React 19", "TypeScript", "D3.js", "Recharts", "Tailwind CSS"
+    ],
+    gradientType: "blue"
+  },
+  {
     title: "tldr-bot",
     category: "Bot",
     callout: null,


### PR DESCRIPTION
## Summary
- Adds Space-Viz to the Projects section — a disk space visualization tool with D3 sunburst and treemap charts
- Positioned between robabby.com and tldr-bot with a blue gradient card

## Test plan
- [ ] Verify Space-Viz card renders in Projects section
- [ ] Verify GitHub link points to https://github.com/robabby/space-viz
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)