### PR TITLE
research(2026-03-20): job market and competitive landscape

### DIFF
--- a/.sherpa/research/competitive/2026-03-20.md
+++ b/.sherpa/research/competitive/2026-03-20.md
@@ -1,0 +1,342 @@
+---
+title: Competitive Landscape — AI-Native Developer Positioning & Thought Leaders
+date: 2026-03-20
+category: competitive
+summary: "Agentic engineering" displaced "vibe coding" as the aspirational professional term (Karpathy, Feb 2026). Jeremy Ron King shipped 367K lines solo in 8 months — Rob's story is stronger. Swift + AI at scale is a rare differentiator with no visible competition.
+---
+
+---
+
+## Summary
+
+Key patterns observed across this research:
+
+- **"Agentic engineering" has officially displaced "vibe coding" as the aspirational professional term.** Andrej Karpathy coined the framing shift (Feb 2026), and it's been widely adopted. The distinction is: vibe coding = no accountability for what the AI produces; agentic engineering = human owns architecture, quality, and correctness while AI executes.
+- **The velocity narrative is the most compelling proof of concept.** The standout voices all lead with numbers: lines of code, PRs merged, platforms shipped, time saved. Quantified output is the currency of credibility in this space.
+- **Solo developer + AI = small team output is the dominant story arc**, but the most respected practitioners frame it as *orchestration*, not automation. The human role is architect, director, reviewer — not typist.
+- **A meaningful counter-narrative exists.** METR's 2025 study (AI caused devs to be 19% slower) created real discourse. The smartest voices acknowledge this nuance rather than ignoring it — which actually *increases* their credibility.
+- **The terminology war is ongoing.** "Agentic engineer," "AI engineer," "context engineer," "harness engineer," "design engineer" — nobody owns this space yet. There's an opportunity for authentic voices to define their own framing.
+
+---
+
+## Searches Conducted
+
+| # | Query | Date |
+|---|-------|------|
+| 1 | `agentic software development engineer 2026` | March 20, 2026 |
+| 2 | `AI-native developer workflow 2025 2026` | March 20, 2026 |
+| 3 | `building with AI engineer blog 2025 2026 solo developer velocity` | March 20, 2026 |
+| 4 | `solo founder AI team scale shipping velocity 2025 story` | March 20, 2026 |
+| 5 | `Simon Willison agentic engineering patterns blog 2026` | March 20, 2026 |
+| 6 | `"agentic engineer" title LinkedIn Twitter prominent voices 2025 2026` | March 20, 2026 |
+| 7 | `Addy Osmani AI coding workflow 2026 developer productivity` | March 20, 2026 |
+| 8 | `vibe coding vs agentic engineering debate 2025 2026 pushback` | March 20, 2026 |
+| 9 | `Andrej Karpathy agentic engineering 2026 AI software developer` | March 20, 2026 |
+| 10 | `developer shipped hundreds PRs AI tools productivity story blog 2025` | March 20, 2026 |
+| 11 | `Thomas Ricouard agentic iOS engineering 2026 IceCubesApp` | March 20, 2026 |
+| 12 | `Jeremy Ron King agentic engineer 367000 lines 2025` | March 20, 2026 |
+| 13 | `Anthropic 2026 agentic coding report key findings case studies` | March 20, 2026 |
+| 14 | `AI productivity paradox METR study 2025 developer slowdown debate` | March 20, 2026 |
+| 15 | `context engineer title Tobi Lutke Shopify AI 10x productivity 2025` | March 20, 2026 |
+| 16 | `Pieter Levels AI revenue solo developer 2025 photorealistic` | March 20, 2026 |
+| 17 | `swyx latent space AI engineer podcast 2025 2026 discourse` | March 20, 2026 |
+
+---
+
+## Notable People & Their Positioning
+
+### Andrej Karpathy
+- **Platform:** Twitter/X, occasional blog posts, lex fridman appearances
+- **Title/framing:** Former OpenAI co-founder, former Tesla AI Director — trades on institutional credibility
+- **What he's saying:** Coined "vibe coding" (2025) and then coined "agentic engineering" (Feb 2026) as the professional evolution. His framing: vibe coding is human as prompt DJ; agentic engineering is human as architect/director of AI agents.
+- **Key quote:** *"You are not writing the code directly 99% of the time… [it's about] directing AI agents, demanding new skills."*
+- **Coverage:** Business Insider, Observer, Times of India all ran pieces on his terminology shift (Feb 8-10, 2026)
+- **URLs:**
+  - https://www.businessinsider.com/agentic-engineering-andrej-karpathy-vibe-coding-2026-2
+  - https://observer.com/2026/02/andrej-karpathy-new-term-ai-coding/
+
+### Simon Willison
+- **Platform:** simonwillison.net (long-running personal blog), Substack newsletter (simonw.substack.com), Mastodon, Twitter/X (@simonw)
+- **Title/framing:** Co-creator of Django, independent developer and AI researcher. Doesn't use "agentic engineer" as a personal title — he's the *documentarian* of the space.
+- **What he's doing:** Published "Agentic Engineering Patterns" guide (Feb 23, 2026) — a growing, chapter-by-chapter documentation of professional practices for working with coding agents (Claude Code, OpenAI Codex). Explicitly distinguishes agentic engineering from vibe coding.
+- **Key quote:** *"Agentic Engineering represents the other end of the scale: professional software engineers using coding agents to improve and accelerate their work by amplifying their existing expertise."*
+- **Key quote (on writing):** *"Writing code is cheap now" — the cost to produce initial working code has dropped to near zero; what changes is everything about how we work.*
+- **Reach:** 345+ posts tagged ai-assisted-programming. HN front-page presence. Newsletter following.
+- **URLs:**
+  - https://simonwillison.net/2026/Feb/23/agentic-engineering-patterns/
+  - https://simonw.substack.com/p/agentic-engineering-patterns
+  - https://news.ycombinator.com/item?id=47243272 (HN discussion)
+
+### Addy Osmani
+- **Platform:** addyosmani.com, Medium (@addyosmani), LinkedIn
+- **Title/framing:** Engineering Lead at Google Chrome. Uses personal credibility (Googler, author of *Learning JavaScript Design Patterns*) to legitimize practical AI workflow guidance.
+- **What he's doing:** Published "Agentic Engineering" post defining the professional paradigm. Wrote "Vibe coding is not the same as AI-Assisted engineering." Published "Beyond Vibe Coding" guide (beyond.addy.ie). Published "My LLM coding workflow going into 2026" (Dec 2025).
+- **Key quote:** *"Agentic engineering = AI does the implementation, human owns the architecture, quality, and correctness. The terminology itself enforces the distinction."*
+- **Key quote (on workflow):** *"Treat the LLM as a powerful pair programmer that requires clear direction, context and oversight rather than autonomous judgment."*
+- **URLs:**
+  - https://addyosmani.com/blog/agentic-engineering/
+  - https://beyond.addy.ie/ (book/guide)
+  - https://addyosmani.com/blog/ai-coding-workflow/
+  - https://medium.com/@addyosmani/vibe-coding-is-not-the-same-as-ai-assisted-engineering-3f81088d5b98
+
+### Thomas Ricouard (@dimillian)
+- **Platform:** Medium, Mastodon, LinkedIn
+- **Title/framing:** Staff iOS Engineer at Medium, maker of IceCubesApp (popular open-source Mastodon client in SwiftUI). A practitioner voice — writes from the trenches, not from institutional authority.
+- **What he's doing:** Published "The State of Agentic iOS Engineering in 2026" (Jan 1, 2026), "The Tipping Point" (Feb 6, 2026), "The Agentic Loop" (Feb 15, 2026). Documents the *shift in mental model* — from using AI for snippets to running multiple agents in parallel.
+- **Key quote:** *"I think the past couple of weeks have probably been the most intensive in terms of AI time contraction. So much happens in so little time, and the collective opinion seems to have shifted. From 'yeah, it works and can write some code for me', to 'wow, I can run multiple agents in parallel to run a bunch of things'. It's a sort of collective awakening."* (Feb 7, 2026)
+- **URLs:**
+  - https://dimillian.medium.com/the-state-of-agentic-ios-engineering-in-2026-c5f0cbaa7b34
+  - https://dimillian.medium.com/the-tipping-point-d624283cbd6d
+  - https://dimillian.medium.com/the-agentic-loop-4230536a8bd2
+
+### Jeremy Ron King
+- **Platform:** jeremyronking.com, Medium (jeremyronking.medium.com)
+- **Title/framing:** Self-described "agentic engineer." 26-year veteran software developer/architect. The *quantified output* guy — probably the most explicit about metrics.
+- **What he's doing:** Published "2025 Year in Review: The Evolution of an Agentic Engineer" — documents 367K lines of code across two platforms in ~8 months, solo, part-time.
+- **Key stats:**
+  - Leaderboard Fantasy (Apr-Sep 2025): 1,140 commits, 139 PRs, 97,532 lines
+  - TutorPro (Oct-Dec 2025): 1,773 commits, 484 PRs, 269,433 lines
+  - Combined: 2,913 commits, 623 PRs, ~367,000 lines of production code and tests
+  - *"For context: in my professional career, projects of this scale typically required teams of 5-10 engineers working for 12-18+ months."*
+- **Also writing:** Claude Code CLI customization, agent workflow tooling
+- **URLs:**
+  - https://jeremyronking.com/blog/2025/30-year-in-review-evolution-of-an-agentic-engineer
+  - https://jeremyronking.medium.com/a-better-claude-code-cli-custom-statusline-script-jeremy-ron-king-59b09d165b90
+
+### Swyx (Shawn Wang)
+- **Platform:** latent.space (Latent Space: The AI Engineer Podcast + newsletter), Twitter/X (@swyx)
+- **Title/framing:** Coined the term "AI Engineer" as a distinct role/category. Runs the most prominent practitioner-facing AI engineering media property.
+- **What he's doing:** Latent Space reached 10M+ readers and listeners in 2025. Covers "Software 3.0" — foundation models changing software engineering. The podcast/newsletter is a major hub for discourse.
+- **Key quote (from newsletter):** *"2026 in AI for Science will look a lot like 2025 in AI for Software Engineering"*
+- **URLs:**
+  - https://www.latent.space/podcast
+  - https://www.latent.space/p/2026 ("Scaling without Slop" — 2026 direction piece)
+
+### Pieter Levels (@levelsio)
+- **Platform:** Twitter/X, levels.io
+- **Title/framing:** The original "solo founder + shipping machine" archetype. Doesn't use "agentic engineering" — predates the terminology — but is the canonical proof-of-concept for solo output.
+- **What he's built:** PhotoAI → $138K MRR (Nov 2025), NomadList → $38K/month. Multiple products. Total reported ARR ~$3M+.
+- **Why he matters:** He's the reference case that validated "one person can build and run a software business at scale." Now AI amplifies this model even further.
+- **URL:** https://www.indiehackers.com/post/photo-ai-by-pieter-levels-complete-deep-dive-case-study-0-to-132k-mrr-in-18-months-3a9a2b1579
+
+### Tobi Lütke (Shopify CEO)
+- **Platform:** Twitter/X
+- **What he said:** Internal memo (leaked/confirmed April 2025): *"Reflexive AI usage is now a baseline expectation at Shopify."* Described AI as a "massive productivity multiplier" — *"turning 10X employees into 100X teams."*
+- **Why it matters:** Provides corporate legitimacy to extreme velocity claims. When the CEO of a $100B+ company says he's seen employees do 100X the work with AI, the narrative gets credibility outside developer circles.
+- **URLs:**
+  - https://x.com/tobi/status/1909251946235437514
+  - https://www.forbes.com/sites/josipamajic/2025/04/08/hire-ai-not-humans-shopify-ceos-radical-mandate-catching-vc-attention/
+
+### Anthropic (Institutional Voice)
+- **What they published:** "2026 Agentic Coding Trends Report" — covers multi-agent systems, human-AI collaboration, scaling agentic coding. Case studies include Rakuten.
+- **Key framing from the report:** *"2025, agentic AI changed how a large swath of developers write code. 2026 is poised to be the year when the systemic effects of this evolutionary shift reconfigure the software development lifecycle."*
+- **URLs:**
+  - https://resources.anthropic.com/2026-agentic-coding-trends-report
+  - https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf
+  - https://tessl.io/blog/8-trends-shaping-software-engineering-in-2026-according-to-anthropics-agentic-coding-report/
+
+---
+
+## Terminology & Framing in Use
+
+### The dominant term cluster (2026):
+- **"Agentic engineering"** — The professional term of art (Karpathy-coined, Feb 2026). Widely adopted.
+- **"Agentic coding"** — Anthropic's preferred term in their report. More neutral/tool-focused.
+- **"AI-assisted development"** — Enterprise/IBM framing. Safer, less exciting.
+- **"AI-native developer"** — Community framing at ainativedev.io. Implies identity, not just tooling.
+
+### What people are calling themselves:
+- **"Agentic engineer"** — Jeremy Ron King, agenticengineer.com community
+- **"AI Engineer"** — swyx/Latent Space community; more established, slightly different connotation (building AI products, not just building with AI)
+- **"Context engineer"** — Emerging title; emphasis on structuring prompts, memory, and context as the core engineering skill
+- **"Agent orchestrator"** — Functional description of the human role in multi-agent systems
+- **"Harness engineer"** — NxCode's framing; builds the scaffolding/infrastructure that makes agents reliable
+- **"Design engineer"** — Used in some circles for full-stack AI-augmented individuals who span design + code
+- **"Software architect"** — Jeremy Ron King's actual job title, even while doing agentic work — interesting that the traditional title still holds
+
+### Key framing distinctions being made:
+- **Vibe coding vs. agentic engineering** — The central distinction. Not the same thing. Vibe coding = no accountability. Agentic engineering = human owns architecture + quality.
+- **"Writing code is cheap now"** (Simon Willison) — The economic framing. The bottleneck has moved from *writing* code to *directing* code.
+- **"Amplifying expertise"** vs. replacing it — The credible voices frame AI as a multiplier of existing skill, not a replacement for it.
+- **"Human-AI collaboration"** — Anthropic's institutional framing.
+- **"Orchestrating agents"** vs. "using AI tools" — The sophistication gradient.
+
+### What's *not* resonating (what to avoid):
+- "10x developer" — Overused, feels like bro-tech self-promotion
+- "AI pair programming" — Too passive; undersells the orchestration
+- "Prompt engineering" — Has become a meme/joke in many circles
+
+---
+
+## Standout Stories / Case Studies
+
+### 1. Jeremy Ron King — 367,000 Lines in 8 Months (Solo, Part-Time)
+The most documented individual velocity case in recent memory.
+- **What:** Two full platforms (Leaderboard Fantasy + TutorPro), ~367K lines of production code + tests
+- **Timeline:** ~8 months, part-time, solo
+- **Tools:** Claude Code, structured agent workflows
+- **Context:** 26-year veteran developer — explicitly frames his *experience* as the multiplier, not the AI alone
+- **Why it matters for Rob:** Almost directly analogous. Different domain, similar story arc.
+- **URL:** https://jeremyronking.com/blog/2025/30-year-in-review-evolution-of-an-agentic-engineer
+
+### 2. Pieter Levels — $3M+ ARR, Zero Employees
+- **What:** Portfolio of AI-powered web products (PhotoAI: $138K MRR, NomadList: $38K/mo, others)
+- **Built solo** — no employees, runs on $3-12K/year in tools
+- **Why it matters:** The canonical "one person = team" proof-of-concept. Predates "agentic engineering" as a term but embodies it.
+- **URL:** https://www.fast-saas.com/blog/pieter-levels-success-story/
+
+### 3. Marc Nuri — Async Multi-Agent Parallel Development
+- **What:** Published "Boosting My Developer Productivity with AI in 2025" documenting restructured workflow with async AI coding agents, multiple Claude Code instances running on different git worktrees simultaneously
+- **Key insight:** The model flips — instead of sequential human → AI → human, you run multiple parallel agents and review/direct asynchronously
+- **URL:** https://blog.marcnuri.com/boosting-developer-productivity-ai-2025
+
+### 4. Anthropic Report — Real Company Case Studies
+- **Companies documented:** Rakuten, TELUS, Zapier, Stripe (via NxCode's guide)
+- **Pattern:** Teams using Claude Code/multi-agent systems for "larger chunks of implementation, working for longer stretches, coordinating with other agents, and reaching users far beyond core engineering teams"
+- **URLs:**
+  - https://resources.anthropic.com/2026-agentic-coding-trends-report
+  - https://www.nxcode.io/resources/news/agentic-engineering-complete-guide-vibe-coding-ai-agents-2026
+
+### 5. Thomas Ricouard — The "Collective Awakening" Observation
+- **Not a specific product story**, but a cultural moment observation worth noting: a Staff Engineer at a major company documenting the *shift in mental model* for iOS engineering in real-time
+- **His framing:** The tipping point wasn't a new model or tool — it was the shift from "AI helps me write code" to "I run multiple agents in parallel"
+- **URL:** https://dimillian.medium.com/the-tipping-point-d624283cbd6d
+
+### 6. Shopify's Tobi Lütke — Enterprise Velocity Claim
+- **Claim:** Employees achieving 100X output with AI on previously "implausible" tasks
+- **Why it matters:** A CEO-level endorsement with specificity gives the velocity narrative corporate legitimacy
+- **URL:** https://x.com/tobi/status/1909251946235437514
+
+---
+
+## Current Discourse & Debates
+
+### Debate 1: "Agentic Engineering vs. Vibe Coding" — The Terminology War
+- Ongoing, active discourse across HN, Reddit (r/vibecoding, r/ClaudeCode, r/OpenAI), dev.to
+- Consensus forming: the distinction is real and matters. Vibe coding = demos that break in production. Agentic engineering = disciplined human oversight.
+- Key HN comment (on Willison's guide): *"One of the biggest struggles I have on my team is coworkers straight up vibing parts of the code and not understanding or guiding the architecture of subsystems."*
+- Turing College piece noted a prediction: *"After three months of seeing what agentic engineering produces first-hand, I think there's going to be a pretty big correction."*
+- **URLs:** https://www.turingcollege.com/blog/agentic-engineering-vs-vibe-coding, https://thenewstack.io/vibe-coding-agentic-engineering/
+
+### Debate 2: The METR Study — AI Slows Developers Down
+- METR's July 2025 RCT found: **when developers are allowed to use AI tools, they take 19% longer to complete issues** — with developers *believing* they were 20% faster
+- This landed like a bomb and got significant coverage
+- **BUT:** METR followed up (Feb 24, 2026) with an updated analysis showing that for the same developers studied later, the model now estimates a speedup of 18% — the early tools may have had worse ROI than current tools
+- The nuanced take: AI is a "highly variable lever that amplifies velocity in specific contexts while actively degrading performance in others" (Baytech Consulting)
+- **Why it matters:** Blanket "AI makes you 10x faster" claims are now scrutinized. Credible voices acknowledge complexity.
+- **URLs:**
+  - https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/
+  - https://metr.org/blog/2026-02-24-uplift-update/
+  - https://scale.com/blog/dev-productivity
+
+### Debate 3: What Skills Actually Matter Now?
+- Emerging consensus: context design, architecture judgment, and review capacity are the new bottleneck
+- Builder.io: *"Engineers become orchestrators in 2026, choosing which agents to scaffold, ship, and maintain"*
+- Chris Roth (cjroth.com): *"The winning formula in early 2026... is structured context (AGENTS.md, architectural guardrails, spec-driven development), tiered rigor... relentless measurement of downstream effects — not just output velocity, but review times, bug rates, change failure rates"*
+- New Stack: *"If you don't engineer the harness, you don't get compounding leverage; you get compounding cognitive debt."*
+- **URLs:**
+  - https://www.builder.io/blog/ai-software-engineer
+  - https://www.cjroth.com/blog/2026-02-18-building-an-elite-engineering-culture
+  - https://thenewstack.io/vibe-coding-agentic-engineering/
+
+### Debate 4: Individual vs. Organizational Velocity — The Paradox
+- Baytech Consulting analysis: while individual developer velocity has increased, organizational throughput often faces new impediments — the "Industrialization of Code" creates review bottlenecks, PR queue backlogs
+- 25% of Google's code is AI-assisted; CEO Sundar Pichai says engineering *velocity* is the real gain (+10% speed), not replacement
+- JetBrains State of Developer Ecosystem 2025: companies shifting from measuring build time / velocity / MTTR to harder-to-quantify outcomes
+- **URL:** https://www.baytechconsulting.com/blog/mastering-ai-code-revolution-2026
+
+### Debate 5: Solo Founders Are About to Outcompete Small Teams
+- Active Reddit thread (r/ClaudeCode, r/OpenAI, March 2026): *"Hot take: solo founders with AI are about to build stuff faster than small teams"*
+- Thread consensus: small teams (2-4 people) with AI may be optimal — small enough to move fast, diverse enough to cover product + engineering + distribution
+- The bureaucracy moat: *"Large companies are still constrained by bureaucracy and the momentum that comes with scale"* — this is the competitive window
+- **URLs:**
+  - https://www.reddit.com/r/ClaudeCode/comments/1ri5pnc/hot_take_solo_founders_with_ai_are_about_to_build/
+  - https://solvedbycode.ai/blog/why-2026-year-ai-native-development
+
+---
+
+## Implications for Rob's Positioning & Voice
+
+### What the landscape reveals about the opportunity:
+
+**1. The "numbers-first" credibility pattern**
+Every standout story leads with hard metrics. Jeremy Ron King's viral post works because of the table with commit counts, PR counts, and line counts. Rob has arguably better numbers (472+ PRs, 6 native Swift apps, one web platform, 11 weeks) and a more interesting story (mid-career professional, not a beginner). **The numbers need to be front-and-center in every version of the story.**
+
+**2. "Agentic engineer" is the right neighborhood, but "Staff Frontend Engineer" is still the anchor**
+The people winning in this space either have institutional credibility (Karpathy, Osmani) or demonstrable output (King, Levels). Rob has both: Staff-level engineering experience AND the output. The title "Agentic Engineer" could work but may read as self-promotional without the backing of a company name. A more grounded framing: *"Staff Engineer building at agentic scale"* or *"senior engineer who spent 11 weeks building at the pace of a team."*
+
+**3. The vibe coding / agentic engineering distinction is a gift**
+Rob didn't vibe code WavePoint. He built a production platform: 6 native Swift apps, a full Next.js web app, monorepo, real architecture. The "I understand the code" framing — owning the architecture, reviewing diffs, writing test suites — differentiates him from the vibe-coders flooding the market. **Lean into this distinction explicitly.**
+
+**4. The "experience as multiplier" narrative is underutilized**
+Jeremy Ron King's post resonates because he frames his 26 years of experience as the thing that made agentic engineering work. Rob has the same story: the AI didn't replace his product instincts or his architecture decisions — it let him execute faster. **The insight is that AI benefits senior engineers MORE than juniors**, because you need to know what good looks like to direct an agent well.
+
+**5. Swift + AI is rare and specific**
+Thomas Ricouard is the most visible iOS/Swift + agentic engineering voice, and he's writing from the perspective of a single-app maintainer. Rob built 6 native Swift apps in 11 weeks. There is essentially nobody in public discourse doing what Rob did at that scale on native iOS. **This is a genuine differentiator in the space.**
+
+**6. Sherpa Studio is the story within the story**
+The discourse is full of "I used AI tools to ship faster." But Rob didn't just use the tooling — he *built* internal tooling (Sherpa Studio) to systematize AI-assisted development. That's a significant step up in sophistication. The comparable positioning: Simon Willison writes about agentic patterns as documentation; Rob built agentic infrastructure as product. **"I built the scaffolding that makes AI dev reliable" is a more defensible positioning than "I used Claude to ship fast."**
+
+**7. The METR study creates an opening**
+The "AI makes everyone faster" claim is being scrutinized. Rob can be credible precisely because he *acknowledges the complexity* — that it takes judgment, architecture experience, and intentional workflow design to capture the gains. The naive velocity bro is being pushback-ed; the thoughtful practitioner has an opening.
+
+### Recommended framing vocabulary for Rob:
+- "Agentic engineering" — use it; it's the right term
+- "Agent orchestration" — for the technical audience
+- "Shipping at team scale" — for the general audience
+- "AI-accelerated development" — neutral, enterprise-friendly
+- "Staff-level + agentic" — the positioning combo
+- Avoid: "10x developer," "vibe coding," "prompt engineering"
+
+### Content opportunities Rob could own:
+- **"What 472 PRs in 11 weeks taught me about agentic engineering"** — metrics + insight piece
+- **"How senior engineers should actually use AI (and why juniors won't thank you for it)"** — opinionated take on the experience-as-multiplier thesis
+- **"Building a 6-app iOS suite with AI: what worked and what didn't"** — rare, specific, valuable
+- **"Why I built Sherpa Studio: the scaffolding no one talks about"** — differentiates from pure user stories
+- **LinkedIn carousel** with the WavePoint/Sherpa velocity numbers — visual proof-of-concept
+
+---
+
+## Sources
+
+### Primary Voices
+- Simon Willison — https://simonwillison.net/2026/Feb/23/agentic-engineering-patterns/
+- Addy Osmani — https://addyosmani.com/blog/agentic-engineering/ | https://beyond.addy.ie/
+- Andrej Karpathy (via coverage) — https://www.businessinsider.com/agentic-engineering-andrej-karpathy-vibe-coding-2026-2
+- Thomas Ricouard — https://dimillian.medium.com/the-state-of-agentic-ios-engineering-in-2026-c5f0cbaa7b34
+- Jeremy Ron King — https://jeremyronking.com/blog/2025/30-year-in-review-evolution-of-an-agentic-engineer
+- swyx / Latent Space — https://www.latent.space/podcast | https://www.latent.space/p/2026
+- Pieter Levels (via case study) — https://www.indiehackers.com/post/photo-ai-by-pieter-levels-complete-deep-dive-case-study-0-to-132k-mrr-in-18-months-3a9a2b1579
+- Tobi Lütke — https://x.com/tobi/status/1909251946235437514
+- Marc Nuri — https://blog.marcnuri.com/boosting-developer-productivity-ai-2025
+
+### Reports & Industry Research
+- Anthropic 2026 Agentic Coding Trends Report — https://resources.anthropic.com/2026-agentic-coding-trends-report
+- METR Developer Productivity Study (July 2025) — https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/
+- METR Updated Analysis (Feb 2026) — https://metr.org/blog/2026-02-24-uplift-update/
+- JetBrains State of Developer Ecosystem 2025 — https://blog.jetbrains.com/research/2025/10/state-of-developer-ecosystem-2025/
+- Baytech Consulting AI Productivity Paradox — https://www.baytechconsulting.com/blog/mastering-ai-code-revolution-2026
+- Jellyfish 2025 AI Metrics in Review — https://jellyfish.co/blog/2025-ai-metrics-in-review/
+- Carta Solo Founders Report 2025 — https://carta.com/data/solo-founders-report/
+
+### Discourse & Commentary
+- The New Stack: Vibe Coding to Agentic Engineering — https://thenewstack.io/vibe-coding-agentic-engineering/
+- The New Stack: 5 Key Trends Agentic Development 2026 — https://thenewstack.io/5-key-trends-shaping-agentic-development-in-2026/
+- Turing College: Agentic Engineering vs. Vibe Coding — https://www.turingcollege.com/blog/agentic-engineering-vs-vibe-coding
+- Addy Osmani: Vibe Coding is not AI-Assisted Engineering — https://medium.com/@addyosmani/vibe-coding-is-not-the-same-as-ai-assisted-engineering-3f81088d5b98
+- Dev.to: Vibe Coding to Agentic Engineering — https://dev.to/jasonguo/from-vibe-coding-to-agentic-engineering-when-coding-becomes-orchestrating-agents-1b0n
+- IBM: What is Agentic Engineering? — https://www.ibm.com/think/topics/agentic-engineering
+- Builder.io: The AI Software Engineer in 2026 — https://www.builder.io/blog/ai-software-engineer
+- Chris Roth: Building Elite AI Engineering Culture — https://www.cjroth.com/blog/2026-02-18-building-an-elite-engineering-culture
+- NxCode: Agentic Engineering Complete Guide — https://www.nxcode.io/resources/news/agentic-engineering-complete-guide-vibe-coding-ai-agents-2026
+- solvedbycode.ai: Why 2026 Is The Year — https://solvedbycode.ai/blog/why-2026-year-ai-native-development
+- Reddit: Solo founders with AI about to outcompete small teams — https://www.reddit.com/r/ClaudeCode/comments/1ri5pnc/hot_take_solo_founders_with_ai_are_about_to_build/
+- agenticengineer.com: Top 2% Roadmap — https://agenticengineer.com/top-2-percent-agentic-engineering
+- HN: Agentic Engineering Patterns discussion — https://news.ycombinator.com/item?id=47243272
+- Scale.com: AI and Developer Productivity — https://scale.com/blog/dev-productivity
+- ODSC: Emerging AI Job Roles 2026 — https://odsc.medium.com/from-context-engineers-to-chief-ai-officers-emerging-ai-job-roles-for-2026-9f757603f547
+- Addy Osmani's LLM workflow (2026) — https://addyosmani.com/blog/ai-coding-workflow/
+
+---
+
+*Research compiled March 20, 2026. The space is moving fast — reassess terminology landscape monthly.*

--- a/.sherpa/research/job-market/2026-03-20.md
+++ b/.sherpa/research/job-market/2026-03-20.md
@@ -1,0 +1,258 @@
+---
+title: AI-Native Engineering Job Market — Titles, Compensation & Target Companies
+date: 2026-03-20
+category: job-market
+summary: Meta validates "Software Engineer AI Native" as a formal title. Stripe posted "Staff Frontend Engineer – AI Design Tooling" — Rob's exact comp. Senior AI-fluent engineers command 20–40% comp premiums. Market bifurcating hard against juniors.
+---
+
+---
+
+## Summary
+
+- **"Agentic AI Engineer" is a real, exploding title** — Citi, Deloitte, Wipro, Quantifyd, Zeta Global, and others are using it verbatim in job postings as of Q1 2026. It's primarily a backend/AI-systems role right now, not frontend-native. The title alone won't resonate with frontend hiring managers.
+- **Meta is literally using "Software Engineer, AI Native"** as a formal job title — multiple open roles as of Feb/Mar 2026. This is the most direct market signal that "AI-Native Engineer" is a recognized, company-level designation (not just a personal branding choice).
+- **Stripe posted "Staff Frontend Engineer – AI Design Tooling"** — hybrid of Rob's exact level + AI-workflow focus. The role was described as building internal AI tools that accelerate prototyping. This is the closest market comp to what Rob actually does.
+- **Senior AI-fluent engineer compensation is real**: Staff/Principal AI Engineers reach $195k–$350k+ total comp; remote averages $180k–$202k base+bonus. AI-fluent senior roles command 20–40% premiums over traditional frontend.
+- **The market is bifurcating**: Junior devs are getting cut (–42% demand), but senior engineers who can architect and orchestrate AI systems are seeing explosive demand growth. Companies like Augment Code are redefining hiring criteria around "agent leverage," product taste, and architectural judgment — exactly what Rob demonstrates.
+
+---
+
+## Searches Conducted
+
+### Search 1: `agentic engineer job posting 2026`
+**Key Results:**
+- Citi: "Agentic AI Engineer – Vice President" (Tampa, hybrid, posted Mar 2026) — LangGraph, autonomous AI flow design, prompt engineering
+- Deloitte: "Agentic AI Engineer-Consultant" — autonomous reasoning, multi-agent systems, ethical deployment
+- Praxent: "Principal Software Engineer (Agentic Dev Specialist)" — Remote
+- Wipro: "Agentic AI Developer" in Redmond, WA (posted Feb 2026)
+- Quantifyd: "Agentic AI Developer" (2025-2026) — LinkedIn posting
+- ZipRecruiter salary range for "Agentic AI Engineer": **$84k–$250k**
+- Glassdoor: 1,130 "agentic AI" jobs in San Francisco alone as of March 2026
+
+**Takeaway:** Title is real and hiring now. Skews toward enterprise (banks, consulting, SaaS). Current postings focus on autonomous agent design + ML orchestration — less frontend-specific.
+
+---
+
+### Search 2: `AI-native engineer job title 2026`
+**Key Results:**
+- **Meta**: "Software Engineer, AI Native" — multiple open roles (Menlo Park, Seattle, New York) as of Feb–Mar 2026. [LinkedIn](https://www.linkedin.com/jobs/view/software-engineer-ai-native-at-meta-4378158733) | [Meta Careers](https://www.metacareers.com/profile/job_details/877951731747100)
+- **Augment Code**: Published "How we hire AI-native engineers now" — defines 6 dimensions: Product & Outcome Taste, System & Architectural Judgment, Agent Leverage, Communication & Collaboration, Ownership & Leadership, Learning Velocity
+- **KORE1 Salary Guide**: Generative AI engineering salaries $140k–$300k+; GenAI Application Developers, RAG Architects, LLM Fine-Tuning Specialists, MLOps/AI Deployment Engineers are the four canonical role types
+- T-Mobile: "Full Stack Principal Software Engineer, Gen AI" (posted Mar 2026)
+- LinkedIn: "AI Engineer" is #1 fastest-growing role in the US, 1.3M+ new AI-enabled jobs globally in the past year
+- AI Engineer (+143.2% growth YoY), AI Solutions Architect (+109.3%)
+
+**Takeaway:** "AI Native" is becoming a legitimate job title modifier. Meta using it officially is the biggest signal. Most companies still append it to SWE/Product Engineer base titles rather than using it standalone.
+
+---
+
+### Search 3: `staff frontend engineer AI workflow job 2026`
+**Key Results:**
+- **Stripe**: "Staff Frontend Engineer – AI Design Tooling" — building internal AI tools to accelerate prototyping and get to production-ready ideas faster
+- **Datadog**: "Staff Software Engineer" with focus on "fast, reliable front-end systems for real-time LLM workflows"
+- **Zapier**: Senior Frontend Engineer — "design and develop complex UIs, lead feature delivery, and integrate AI into products"
+- **GitLab**: Staff Frontend Engineer job description (updated Mar 2026) — explicitly states "all team members are encouraged and expected to incorporate AI into their daily workflows"
+- **ZipRecruiter**: AI Front-End Developer salary range: **$104k–$350k**
+- **Built In NYC**: Building "agentic interfaces" for complex workflows — cited as key frontend responsibility
+- Authentic Jobs report: "AI Frontend Developer," "ML Interface Engineer," "AI Product Developer" are emerging hybrid titles; salaries 20–40% above traditional frontend
+
+**Takeaway:** "Staff Frontend Engineer" + AI context is hiring. The Stripe role is the most direct comp. "Agentic interfaces" and "LLM workflow UIs" are appearing as frontend responsibilities.
+
+---
+
+### Search 4: `senior engineer AI tools job description skills 2026 cursor copilot`
+**Key Results:**
+- **The Pragmatic Engineer** (Feb 2026 survey of ~1,000 engineers):
+  - Claude Code rocketed to #1 AI tool in 8 months (overtook Copilot, Cursor)
+  - 95% of respondents use AI tools weekly
+  - 75% use AI for 50%+ of their work
+  - Staff+ engineers lead AI agent adoption at 63.5%
+  - Claude Code is most loved tool (46%), Cursor (19%), Copilot (9%)
+  - Senior engineering leaders are "obsessed" with Claude Code
+- **ZipRecruiter job postings** explicitly list: "Using Claude Code, Cursor, v0, or similar tools to accelerate builds" as required experience
+- **Second Talent**: "GitHub Copilot writes 40% of code in files where it runs. Companies need people who can architect systems that use AI."
+- Medium (Mar 2026): "In 2026, developers who effectively leverage AI coding assistants... increase their value significantly. The skill isn't competing with AI — it's multiplying yourself with AI."
+
+**Takeaway:** AI tool fluency (Claude Code, Cursor, Copilot, v0) is now expected in senior job descriptions — not a differentiator alone, but a table-stakes qualifier. Claude Code specifically is the current prestige tool for senior engineers.
+
+---
+
+### Search 5: `companies hiring AI-accelerated development workflow engineers 2026`
+**Key Results:**
+- **Second Talent** (Mar 2026): Role demand changes vs. 2023:
+  - Junior Full-Stack: **–42%**
+  - ML Engineer: **+156%**  
+  - Senior Backend: **+23%**
+  - LLM Engineer: **+890%** (new role)
+  - Data Engineer: **+67%**
+- Reuters (Feb 2026): "What's the hottest job in AI right now?" — "Artificial Intelligencer" — embedding with customers at OpenAI, Anthropic focusing on regulated industries
+- Augment Code blog: Redefining engineering competence around agent orchestration, not code-writing
+- Final Round AI: "Companies used to hire junior developers... In 2026, that's increasingly rare. They need engineers who can architect systems that use AI."
+
+**Takeaway:** The market signal is clear — LLM/AI engineering roles are exploding in demand, traditional full-stack is contracting. Senior engineers who can architect AI systems and ship products at velocity are what companies need.
+
+---
+
+### Search 6: `"10x engineer" OR "vibe coding" OR "AI accelerated" senior engineer job posting`
+**Key Results:**
+- **VibeCodeCareers.com**: Job board specifically for AI-fluent developers. Job titles: "AI-First Developer," "Product Engineer," "Full Stack AI Developer," "Creative Technologist"
+- Internshala posting: "We are looking for an engineer who treats AI (Codex, Cursor, LLMs, Agents) like a superpower to ship high-fidelity financial systems at 10x speed"
+- ZipRecruiter: "Vibe Coding Engineer who operates at the intersection of AI-assisted development, rapid prototyping, and production-grade execution"
+- Dev.to (Mar 2026): "The 10x Engineer in 2026: Coding speed is commoditized — judgment is scarce"
+
+**Takeaway:** "Vibe coding" is entering job postings. Startups and early-stage companies are actively seeking engineers who operate at 10x with AI. This is Rob's wheelhouse — just needs the right framing.
+
+---
+
+### Search 7: `HN Who Is Hiring March 2026 — React roles`
+**Key Results from HN March 2026:**
+- **Regal.ai** (AI Agent Platform): Sr. SWE, NYC Hybrid — Python/TS/React/NestJS, 5-12+ yrs, AI/LLM exp "a big plus." Stack: Python, TypeScript/Node.js, React, NestJS, GraphQL, Postgres, Redis, AWS
+- **Breezy** (field service software): "AI Product Engineer" (Mid-Senior), Remote US, **$120k–$150k + equity** — TypeScript, React, Node.js, PostgreSQL + LLMs. Explicitly states: "Engineers on our team regularly use modern development tools such as Claude Code, Codex, and Cursor as part of their workflow."
+- Multiple startups using React + AI + TypeScript stack, emphasizing end-to-end ownership
+
+---
+
+### Search 8: `Citi Agentic AI Engineer job description`
+**Citi "Agentic AI Engineer – VP"** (Tampa, FL, Hybrid, posted Mar 9, 2026):
+- LangGraph framework expertise
+- End-to-end agentic flow design, prompt engineering, comprehensive testing
+- MLOps practices, architecture reviews, design pattern publishing
+- "Strategic professional deeply immersed in AI/ML"
+
+---
+
+## Emerging Titles & Patterns
+
+| Title | Where Used | Seniority | Notes |
+|---|---|---|---|
+| **Agentic AI Engineer** | Citi, Deloitte, Wipro, Quantifyd, Zeta Global | Mid–VP | Backend/ML heavy; autonomous agent systems |
+| **Software Engineer, AI Native** | **Meta** | IC3–IC6 | Formal Meta title, multiple open roles Mar 2026 |
+| **Staff Frontend Engineer – AI Design Tooling** | **Stripe** | Staff | Closest match to Rob's profile |
+| **Full Stack Principal SWE, Gen AI** | T-Mobile | Principal | GenAI-focused fullstack |
+| **AI Product Engineer** | Breezy, other startups | Mid–Senior | Product-oriented; Claude/Cursor workflow expected |
+| **Vibe Coding Engineer** | Startups | Varies | AI-accelerated shipping; rapid prototyping |
+| **AI-First Developer** | VibeCodeCareers | Varies | Emerging on AI-native job boards |
+| **Product Engineer** | Startups | Mid–Staff | Broad scope; AI assumed |
+| **LLM Engineer** | Regal.ai, startups | Senior | LLM integration specialist |
+| **GenAI Application Developer** | Consulting/Enterprise | Mid–Senior | KORE1 canonical category |
+
+**Emerging Pattern:** Companies are converging on the "Software Engineer + [AI modifier]" pattern (e.g., "Software Engineer, AI Native" at Meta). The modifier signals the expected working style, not just a skill list.
+
+---
+
+## Notable Companies & Roles
+
+### Tier 1: Big Tech (explicit AI-native roles)
+- **Meta**: "Software Engineer, AI Native" — Seattle, NYC, Menlo Park. Multiple open roles Feb–Mar 2026. Most direct market signal for the title.
+- **Stripe**: "Staff Frontend Engineer – AI Design Tooling" — Building internal AI tools to accelerate production workflows. Direct comp for Rob.
+- **Datadog**: Staff SWE — "frontend systems for real-time LLM workflows"
+
+### Tier 2: Mid-Market / High-Growth
+- **Zapier**: Senior Frontend — integrating AI into products
+- **Regal.ai** (AI Agent Platform, $82M raised): Sr. SWE, React/TS/Python, LLM-heavy
+- **GitLab**: Staff Frontend (AI use explicitly expected organization-wide)
+- **Moveworks**: Agent Lab SWE — agent orchestration, memory, multimodal I/O (Glassdoor SF listing)
+
+### Tier 3: Startups (AI-velocity focus)
+- **Breezy**: "AI Product Engineer" — $120k–$150k + equity, Remote, React/TS, Claude Code/Codex/Cursor required
+- **Augment Code**: Hiring with AI-native criteria (product taste, agent leverage, architectural judgment)
+- **Praxent**: "Principal SWE (Agentic Dev Specialist)" — Remote
+
+### Consulting/Enterprise
+- **Citi**: Agentic AI Engineer VP — LangGraph, prompt engineering, autonomous AI systems
+- **Deloitte**: Agentic AI Engineer-Consultant
+- **Wipro**: Agentic AI Developer, Redmond WA
+
+### Active HN "Who Is Hiring" March 2026 pool
+See: https://hnhiring.com/technologies/react — Multiple React/TS + AI roles from seed to Series B.
+
+---
+
+## Compensation Signals
+
+| Level | Base Salary | Total Comp | Notes |
+|---|---|---|---|
+| **Entry-level AI Engineer** | $100k–$140k | $100k–$173k | BLS median ~$145k |
+| **Mid-level AI Engineer** | $160k–$210k | $185k–$265k | KORE1 2026 guide |
+| **Senior AI Engineer** | ~$212k | $195k–$350k+ | Codecademy/exceeds.ai |
+| **Staff/Principal AI Engineer** | N/A | up to **$943k** | Levels.fyi top end (FAANG) |
+| **Remote AI Engineer (avg)** | $180k | $202k total | Built In 2026 |
+| **AI Front-End Developer** | $104k–$350k | — | ZipRecruiter range |
+| **Agentic AI Engineer** | $84k–$250k | — | ZipRecruiter range |
+| **Vibe Coding Engineer** | $15–$67/hr | — | ZipRecruiter (contractor heavy) |
+| **Breezy AI Product Engineer** | $120k–$150k | +equity | Remote startup, HN March 2026 |
+| **SF Bay Area Senior AI Engineer** | $186k–$207k | >$300k+ total | Codecademy; FAANG premium |
+| **GenAI Engineer (KORE1 estimate)** | $140k–$300k+ | — | Broad market range |
+
+**LLM Engineer** exploded from $0 to existence: Anthropic prompt engineer roles listed at $250k–$375k in SF; remote Southeast Asia equivalent $60k–$90k.
+
+---
+
+## Implications for Rob's Positioning
+
+### 1. "Staff Frontend Engineer" is still the safest anchor
+It's the most searchable, understood, recruiter-friendly title. The market pays $140k–$250k+ for Staff-level frontend with AI context. **Don't abandon it** — but add an AI modifier.
+
+### 2. "AI-Native Engineer" has the most prestigious market validation
+Meta using "Software Engineer, AI Native" as a formal title is huge. It's now a term companies use themselves, not just a personal brand. This validates Rob's instinct. **Best for:** tech-forward companies, startups, product companies.
+
+### 3. "Agentic Engineer" is real but skews backend/enterprise
+Current "Agentic AI Engineer" postings are from Citi, Deloitte, Wipro — they're primarily looking for Python/LangGraph/ML architects, not frontend engineers. **Risk:** Misaligns expectations. If Rob uses this title, he needs to be clear it's in the context of AI-workflow orchestration (building Sherpa Studio), not autonomous ML agent systems.
+
+### 4. The Augment Code framework is the best interview narrative
+Their 6 dimensions of AI-native engineering map directly to Rob's work:
+- **Product & Outcome Taste** → WavePoint: 472 PRs, shipping real products with real design voice ("Modern Mystic")
+- **Agent Leverage** → Sherpa Studio: built tooling that turns AI into engineering throughput
+- **System & Architectural Judgment** → monorepo architecture, extracting packages, pnpm workspace management
+- **Learning Velocity** → went from idea to 6 Swift apps + web platform in 11 weeks
+- **Ownership & Leadership** → entire stack owned solo; made architectural decisions autonomously
+
+### 5. The velocity story is the differentiator
+The market is bifurcating: junior roles collapsing, senior AI-savvy roles exploding. Rob's 472+ PRs in 11 weeks is exactly what "10x with AI" looks like in practice. This is the lead narrative — not the title.
+
+### 6. Recommended title variants (priority order)
+1. **Staff Engineer, AI-Native** — broadest appeal, Meta-validated
+2. **Staff Frontend Engineer** — classic, recruiter-friendly, safe
+3. **AI Product Engineer** — startup-forward, shows product + engineering
+4. **Staff Software Engineer** — level-clear, lets the portfolio speak
+
+### 7. Target companies
+Based on this research, ideal targets for Rob's profile:
+- **Stripe, Vercel, Linear, Loom, Figma, Clerk, Supabase** — product-led, AI-native workflows valued, likely hiring Staff Frontend
+- **Augment Code** — literally rewrote their hiring criteria around AI-native engineers; Rob would pass their rubric
+- **Meta** — "AI Native" is their own title
+- **Zapier, Datadog** — AI-integrated frontend work, React/TS stack
+- **Series A/B startups** on HN "Who Is Hiring" with Claude Code/Cursor requirement in JD
+
+---
+
+## Sources
+
+1. Augment Code — "How we hire AI-native engineers now": https://www.augmentcode.com/blog/how-we-hire-ai-native-engineers-now
+2. Second Talent — "How AI Is Changing Engineering Talent Demand in 2026": https://www.secondtalent.com/resources/how-ai-is-changing-engineering-talent-demand/
+3. Pragmatic Engineer — "AI Tooling for Software Engineers in 2026": https://newsletter.pragmaticengineer.com/p/ai-tooling-2026
+4. Citi Careers — "Agentic AI Engineer VP": https://jobs.citi.com/job/tampa/agentic-ai-engineer-vice-president/287/92572658384
+5. Deloitte — "Agentic AI Engineer-Consultant": https://usijobs.deloitte.com/en_US/careersUSI/JobDetail/USI-EH26-Consulting-Services-AI-E-EaaS-SWE-Consultant-Agentic-AI-Engineer/317603
+6. Meta Careers — "Software Engineer, AI Native": https://www.metacareers.com/profile/job_details/877951731747100
+7. Meta via LinkedIn — "Software Engineer, AI Native" (Seattle): https://www.linkedin.com/jobs/view/software-engineer-ai-native-at-meta-4378158733
+8. Stripe Careers — "Staff Frontend Engineer – AI Design Tooling": https://stripe.com/jobs/listing/staff-frontend-engineer-ai-design-tooling/7683133
+9. KORE1 — "How to Hire Generative AI Engineers in 2026": https://www.kore1.com/hire-generative-ai-engineers/
+10. KORE1 — "AI Engineer Salary Guide 2026": https://www.kore1.com/ai-engineer-salary-guide/
+11. Exceeds.ai — "AI Engineer Salary 2026": https://blog.exceeds.ai/ai-engineer-salary/
+12. Built In — "2026 AI Engineer Salary Remote": https://builtin.com/salaries/us/remote/ai-engineer
+13. Glassdoor — "Remote AI Engineer Salary": https://www.glassdoor.com/Salaries/remote-ai-engineer-salary-SRCH_IL.0,6_IS12617_KO7,18.htm
+14. ZipRecruiter — "Agentic AI Engineer Jobs": https://www.ziprecruiter.com/Jobs/Agentic-Ai-Engineer
+15. ZipRecruiter — "AI Front-End Developer Jobs": https://www.ziprecruiter.com/Jobs/Ai-Front-End-Developer
+16. Authentic Jobs — "Frontend to AI Developer Career Guide": https://authenticjobs.com/frontend-developer-to-ai-developer-career-guide/
+17. VibeCodeCareers — https://vibecodecareers.com/
+18. HN Hiring March 2026 (React roles): https://hnhiring.com/technologies/react
+19. Let's Data Science — "AI Engineer Roadmap 2026": https://letsdatascience.com/blog/ai-engineer-roadmap-2026-skills-tools-and-career-path
+20. Codecademy — "AI Engineer Salary Guide 2026": https://www.codecademy.com/resources/blog/how-much-does-an-ai-engineer-make
+21. Dev.to — "The 10x Engineer in 2026": https://dev.to/hainanzhao/the-10x-engineer-in-2026-what-actually-matters-after-ai-changed-everything-1g9m
+22. Reuters — "What's the hottest job in AI right now?": https://www.reuters.com/technology/artificial-intelligence/artificial-intelligencer-hottest-job-ai-right-now-2026-02-26/
+23. Yallo.co — "Future of AI Jobs in 2026": https://yallo.co/insights/news/future-of-ai-jobs-2026/
+24. GitLab — Staff Frontend Engineer job description (updated Mar 2026): https://handbook.gitlab.com/job-description-library/engineering/development/frontend/staff/
+
+---
+
+*Research conducted by Luna (Sherpa AI) on March 20, 2026. Feeds into Rob's job search positioning strategy.*


### PR DESCRIPTION
First research output written to `.sherpa/research/` format for Studio research viewer.

## Files

- `.sherpa/research/job-market/2026-03-20.md` — AI-native engineering titles, compensation signals, target companies (Stripe, Meta, Augment Code)
- `.sherpa/research/competitive/2026-03-20.md` — Agentic engineering landscape, thought leaders (Karpathy, Osmani, Willison), Rob's positioning opportunities

## Format

Both files have YAML frontmatter with `title`, `date`, `category`, and `summary` fields — compatible with Studio's research viewer at `studio.sherpa.solar/projects/robabby/research/{category}/{date}`.

## Notes

This is the first end-to-end test of the Luna → git → Studio research loop. Merging this verifies the full pipeline.