### PR TITLE
research(2026-03-21): job market update

### DIFF
--- a/.sherpa/research/job-market/2026-03-21.md
+++ b/.sherpa/research/job-market/2026-03-21.md
@@ -1,0 +1,251 @@
+---
+title: Job Market & Positioning Research — AI-Native / Agentic Engineering Roles
+date: 2026-03-21
+category: job-market
+summary: "Agentic AI Engineer" is a real, growing job title used by Citi, Deloitte, Accenture, and startups — primarily for ML/infra-heavy roles. "AI-Native Engineer" is an emerging internal hiring lens (Augment Code leads the discourse), not yet a widespread posted title. Staff Frontend Engineers who demonstrably use AI tools are commanding 20-40% salary premiums, and the clearest positioning opportunity for Rob is as a high-velocity product engineer whose AI-augmented workflow is a measurable differentiator.
+---
+
+## Summary
+
+- **"Agentic AI Engineer"** exists as a real title (Citi, Deloitte, Accenture, ZipRecruiter shows $84K–$250K range) but skews toward LLM/MLOps/agent infrastructure roles — not product-facing frontend work. Claiming it without ML depth risks misalignment.
+- **"AI-Native Engineer"** is more of a hiring _lens_ than a posted title. Augment Code published influential criteria for what this means in practice — and Rob matches it almost perfectly (product taste, architectural judgment, agent leverage, high learning velocity).
+- **Staff Frontend Engineer with AI emphasis** is the safest searchable title with strong comp ($166K–$267K Glassdoor; top FAANG/startup ICs $300K–$600K), and companies are now explicitly requiring AI tool proficiency (Cursor, Claude Code, Copilot) in JDs.
+- **Claude Code has dethroned GitHub Copilot** as the #1 AI coding tool (Pragmatic Engineer survey, Feb 2026): 95% of engineers use AI weekly, 56% do 70%+ of work with AI. Staff+ engineers lead AI agent adoption at 63.5%. Rob's workflow is ahead of the curve.
+- **The market bifurcation is clear:** Junior/generalist demand dropped ~42%; senior roles requiring AI architectural judgment grew 23%+; LLM engineering roles exploded +890%. Rob is on exactly the right side of this split.
+
+---
+
+## Searches Conducted
+
+### Search 1: `agentic engineer job posting 2026`
+
+**Top Results:**
+- [ZipRecruiter: Agentic AI Engineer jobs, $84K–$250K](https://www.ziprecruiter.com/Jobs/Agentic-Ai-Engineer)
+- [Citi: Agentic AI Engineer – Vice President, Tampa](https://jobs.citi.com/job/tampa/agentic-ai-engineer-vice-president/287/92572658384)
+- [Deloitte: Agentic AI Engineer – Consultant](https://usijobs.deloitte.com/en_US/careersUSI/JobDetail/USI-EH26-Consulting-Services-AI-E-EaaS-SWE-Consultant-Agentic-AI-Engineer/317603)
+- [Accenture: Google Agentic AI Delivery Specialist](https://www.accenture.com/us-en/careers/jobdetails?id=R00306801_en)
+- [Indeed: Agentic AI Engineering Jobs](https://www.indeed.com/q-agentic-ai-engineering-job-jobs.html)
+- [Glassdoor: 1,130 agentic AI jobs in San Francisco](https://www.glassdoor.com/Job/san-francisco-agentic-ai-jobs-SRCH_IL.0,13_IC1147401_KO14,24.htm)
+- [LinkedIn: Agentic AI Developer 2025–2026 at Quantifyd](https://www.linkedin.com/jobs/view/agentic-ai-developer-2025-2026-at-quantifyd-4261208571)
+
+**Key Takeaways:**
+- "Agentic AI Engineer" is a legitimate and growing title, primarily at large enterprises (Citi VP-level), consulting firms (Deloitte, Accenture), and AI-native startups.
+- Citi's posting describes: "leading agentic flow design, prompt design, and comprehensive testing."
+- Deloitte focuses on: "design, develop, and deploy advanced AI agents capable of autonomous reasoning, decision-making, and self-directed task execution."
+- Accenture wants someone comfortable "building a multi-agent workflow on Vertex AI" with a "consultative mindset" — more solutions-architect than product engineer.
+- These roles are predominantly infrastructure/ML-layer, not product UI — important nuance for Rob's positioning.
+
+---
+
+### Search 2: `AI-native engineer job title 2026`
+
+**Top Results:**
+- [Augment Code: How we hire AI-native engineers now](https://www.augmentcode.com/blog/how-we-hire-ai-native-engineers-now) ⭐ Must-read
+- [Let's Data Science: AI Engineer Roadmap 2026](https://letsdatascience.com/blog/ai-engineer-roadmap-2026-skills-tools-and-career-path)
+- [KORE1: How to Hire Generative AI Engineers in 2026](https://www.kore1.com/hire-generative-ai-engineers/)
+- [ZipRecruiter: Meta Software Engineer, AI Native – Menlo Park](https://www.ziprecruiter.com/c/Meta/Job/Software-Engineer,-AI-Native/-in-New-York,NY?jid=eb250fd9b239140a)
+- [T-Mobile: Full Stack Principal Software Engineer, Gen AI](https://careers.t-mobile.com/full-stack-principal-software-engineer-gen-ai/job/74542D3F937BD256F6B182F82155BF0C)
+- [Yallo: Future of AI Jobs in 2026](https://yallo.co/insights/news/future-of-ai-jobs-2026/)
+
+**Key Takeaways:**
+- **Meta is using "Software Engineer, AI Native"** as a literal job title (posted Feb 26, 2026) — this is significant signal from a FAANG.
+- **Augment Code published a landmark post** on what "AI-native engineering" means in hiring: they explicitly say _raw coding ability is no longer the primary differentiator_. The six new dimensions they look for: Product & Outcome Taste, System & Architectural Judgment, Agent Leverage, Communication & Collaboration, Ownership & Leadership, Learning Velocity.
+- "AI Engineer" tops LinkedIn's fastest-growing roles in the US, with 1.3M+ new AI-enabled jobs created globally in the past year.
+- "AI-Native Engineer" isn't a widely searchable job title yet — it's more of a positioning/cultural descriptor. Using it as a subtitle or in a narrative ("AI-native engineering practice") may be more effective than as a primary title.
+
+---
+
+### Search 3: `staff frontend engineer AI workflow job 2026`
+
+**Top Results:**
+- [GitLab: Staff Frontend Engineer – handbook](https://handbook.gitlab.com/job-description-library/engineering/development/frontend/staff/) (notes AI integration is expected of _all_ team members)
+- [Authentic Jobs: Frontend Developer to AI Developer – Career Guide](https://authenticjobs.com/frontend-developer-to-ai-developer-career-guide/)
+- [ZipRecruiter: AI Front End Developer, $104K–$350K](https://www.ziprecruiter.com/Jobs/Ai-Front-End-Developer?version=next)
+- [Built In SF: Staff Frontend Engineer at Verkada](https://www.builtinsf.com/jobs/dev-engineering/front-end)
+- [Built In NYC: Staff Software Engineer at Datadog – frontend/LLM systems](https://www.builtinnyc.com/jobs/dev-engineering/front-end)
+- [Built In Colorado: Senior Frontend Engineer at Zapier – AI product integration](https://www.builtincolorado.com/jobs/dev-engineering/front-end)
+
+**Key Takeaways:**
+- **GitLab's staff-level JD now explicitly includes AI workflow expectations** — it's becoming a baseline, not a differentiator, at staff level.
+- **Datadog is hiring Staff Software Engineers** for "fast, reliable front-end systems for real-time LLM workflows" — a direct frontend+AI intersection.
+- **Zapier** wants senior frontend engineers who "design and develop complex UIs, lead feature delivery, and integrate AI into products."
+- AI-related job postings for frontend/fullstack have grown 200%+ in 2 years; salaries 20–40% above pure frontend roles.
+- Hybrid titles emerging: "AI Frontend Developer," "ML Interface Engineer," "AI Product Developer."
+
+---
+
+### Search 4: `senior engineer AI tools job description skills 2026 React TypeScript`
+
+**Top Results:**
+- [HN Hiring (March 2026): React jobs](https://hnhiring.com/technologies/react) — active real-time data
+- [Retell AI (YC): Senior Software Engineer, Frontend](https://www.ycombinator.com/companies/retell-ai/jobs/K4zoWVp-senior-software-engineer-frontend)
+- [Web3.career: Remote React Jobs](https://web3.career/react+remote-jobs)
+- [Medium: The React Developer Job Market in 2026](https://medium.com/@reactjsbd/the-react-developer-job-market-in-2026-navigating-the-ai-revolution-9bbdc2b14f02)
+- [Course Report: 7 Skills for AI Engineers 2026](https://www.coursereport.com/blog/7-skills-you-need-to-become-an-ai-engineer-in-2026)
+
+**Key Takeaways:**
+- **HN March 2026 hiring thread** shows senior fullstack roles: "React/Next.js, Node.js/TypeScript/GraphQL" paired with "Agent layer, eval methodology, context pipelines, model selection" — the stack Rob knows.
+- **Web3.career JD (real posting, March 2026):** "Active, proficient use of AI-assisted development tools (Cursor, Claude Code, GitHub Copilot, or equivalent). We expect the majority of your development workflow to be AI-augmented — this is a core engineering practice on our team, not optional." — This exact sentence is becoming more common.
+- Most in-demand stack for senior AI-frontend hybrids: React, Next.js, TypeScript, Supabase/Postgres, LLM APIs (OpenAI/Anthropic), Cursor/Claude Code.
+- React remains dominant but the differentiator is AI tool fluency layered on top.
+
+---
+
+### Search 5: `Cursor Copilot AI tools required senior engineer job posting 2026`
+
+**Top Results:**
+- [Pragmatic Engineer: AI Tooling for Software Engineers in 2026](https://newsletter.pragmaticengineer.com/p/ai-tooling-2026) ⭐ Key data
+- [ZipRecruiter: Cursor AI Jobs](https://www.ziprecruiter.com/Jobs/Cursor-Ai)
+- [Indeed: Cursor AI Engineering jobs](https://www.indeed.com/q-cursor-ai-jobs.html)
+
+**Key Takeaways (Pragmatic Engineer survey, n≈1,000, Jan–Feb 2026):**
+- **Claude Code is now the #1 AI coding tool**, overtaking GitHub Copilot and Cursor — in just 8 months since May 2025.
+- 95% of engineers surveyed use AI tools at least weekly; 75% use AI for half or more of their work; 56% report 70%+ of engineering done with AI.
+- **Staff+ engineers lead AI agent adoption** at 63.5% regular usage — nearly double non-agent-using counterparts' enthusiasm.
+- Claude Code most loved at 46% (vs. Cursor 19%, Copilot 9%).
+- Companies explicitly listing in JDs: Claude Code, Cursor, GitHub Copilot, v0.dev — with expectation of "majority of workflow AI-augmented."
+
+---
+
+### Search 6: `staff frontend engineer AI salary compensation 2026`
+
+**Top Results:**
+- [Glassdoor: Staff Frontend Engineer salary 2026](https://www.glassdoor.com/Salaries/staff-frontend-engineer-salary-SRCH_KO0,23.htm)
+- [ZipRecruiter: Staff Frontend Engineer avg salary 2026](https://www.ziprecruiter.com/Salaries/Staff-Frontend-Engineer-Salary)
+- [Glassdoor: AI Engineer salary 2026](https://www.glassdoor.com/Salaries/ai-engineer-salary-SRCH_KO0,11.htm)
+- [Levels.fyi: AI Engineer salary](https://www.levels.fyi/t/software-engineer/title/ai-engineer)
+- [KORE1: AI Engineer Salary Guide 2026](https://www.kore1.com/ai-engineer-salary-guide/)
+- [Exceeds.ai: AI Engineer Salary 2026](https://blog.exceeds.ai/ai-engineer-salary/)
+- [NuCamp: Top 10 Highest-Paying Frontend/Fullstack Jobs 2026](https://www.nucamp.co/blog/top-10-highest-paying-full-stack-and-frontend-jobs-in-2026-salary-breakdown)
+
+**Key Takeaways:**
+- **Staff Frontend Engineer (Glassdoor, March 2026):** $166,462 (25th pct) – $267,095 (75th pct) base. Average ~$168K ZipRecruiter.
+- **Staff/Senior Staff Frontend at FAANG/top startups (NuCamp, Levels):** $300K–$600K total comp.
+- **AI Engineer (Glassdoor):** $112,852–$179,002 base. Median $154K (Levels.fyi). Loaded comp (base + equity + bonus): $140K–$293K (Levels, 9,517 data points).
+- **Generative AI specialists (KORE1, citing Vidhya research):** Average $174,727, top performers clearing $300K.
+- **Mid-level AI Engineer (KORE1):** $160K–$210K base + 15–25% bonuses/equity = $185K–$265K loaded.
+- **Key insight:** A "Staff Frontend Engineer with AI workflow expertise" at a well-funded AI startup should realistically target $220K–$350K total comp.
+
+---
+
+## Emerging Titles & Patterns
+
+### Active Job Titles (Real Postings Confirmed March 2026)
+| Title | Where | Level | Focus |
+|---|---|---|---|
+| Agentic AI Engineer | Citi, Deloitte, Accenture | VP / Consultant | LLM infra, agent design |
+| Software Engineer, AI Native | Meta | IC | Product AI integration |
+| Full Stack Principal Software Engineer, Gen AI | T-Mobile | Principal | Fullstack + GenAI |
+| Senior Software Engineer, Frontend (AI) | Retell AI (YC) | Senior | AI voice product UI |
+| Staff Software Engineer (frontend/LLM) | Datadog | Staff | Real-time LLM systems |
+| AI Frontend Developer | Various (ZipRecruiter) | Mid–Senior | UI for AI products |
+| Agentic AI Developer | Quantifyd (LinkedIn) | IC | Agent workflows |
+| AI Integration Engineer | Multiple | Mid | API integration |
+
+### Patterns in JD Language (2026)
+1. **AI tool proficiency is now table stakes**, not a differentiator: "We expect the majority of your workflow to be AI-augmented — this is a core engineering practice, not optional."
+2. **Agent orchestration language appearing in product engineer JDs**: "Build agentic workflows," "orchestrate agents," "work alongside increasingly capable AI agents."
+3. **Velocity + throughput mentioned explicitly**: Companies reducing headcount while shipping more, seeking engineers who provide 3-5x leverage.
+4. **The 6 AI-native hiring dimensions** (Augment Code framework, gaining industry adoption): Product taste → Architectural judgment → Agent leverage → Communication → Ownership → Learning velocity.
+5. **"AI-accelerated" as a differentiator**: Candidates who can demonstrate quantifiable output velocity are standing out.
+
+---
+
+## Notable Companies & Roles
+
+### Enterprise / Large Tech
+- **Meta**: "Software Engineer, AI Native" — explicit title, Menlo Park/NYC, posted Feb 2026
+- **Citi**: "Agentic AI Engineer – VP" — senior finance-sector AI role
+- **Deloitte**: "Agentic AI Engineer – Consultant" — consulting layer
+- **Accenture**: "Google Agentic AI Delivery Specialist" — Vertex AI / multi-agent
+- **T-Mobile**: "Full Stack Principal Software Engineer, Gen AI" — telco going AI-native
+- **Datadog**: Staff Software Engineer for LLM-facing frontend systems
+
+### AI-Native / YC-Funded
+- **Augment Code**: Hiring AI-native engineers; published the playbook for what this means
+- **Retell AI (YC)**: Senior Frontend SWE — voice AI product
+- **329 YC AI startups** in SF Bay Area actively hiring (March 2026)
+- **Moveworks**: "Agent Lab" NLU software engineers — agent orchestration, memory, LLM self-reflection
+- **Various YC W26 startups**: Medical AI, workflow automation — all wanting "AI-augmented" engineers
+
+### Aggregators Worth Monitoring
+- [YC Companies Hiring (AI)](https://www.ycombinator.com/companies/industry/ai/san-francisco-bay-area/hiring) — 329 active
+- [Built In SF Frontend Jobs](https://www.builtinsf.com/jobs/dev-engineering/front-end)
+- [Built In NYC Frontend Jobs](https://www.builtinnyc.com/jobs/dev-engineering/front-end)
+- [startup.jobs AI](https://startup.jobs/artificial-intelligence-jobs) — 1,052 roles active
+- [HN Hiring thread (March 2026)](https://hnhiring.com/technologies/react)
+
+---
+
+## Compensation Signals
+
+| Role / Level | Base Salary | Total Comp (incl. equity) |
+|---|---|---|
+| Staff Frontend Engineer (US, all companies) | $166K–$267K | $200K–$350K |
+| Staff Frontend at FAANG / top AI startup | $200K–$350K | $300K–$600K |
+| AI Engineer (all levels, Glassdoor) | $113K–$179K | — |
+| AI Engineer (Levels.fyi, median) | ~$154K | ~$211K avg |
+| Gen AI Specialist (senior) | $174K avg | $300K+ top performers |
+| Agentic AI Engineer (enterprise, VP-level) | ~$200K+ | — |
+| AI coding role (Anthropic prompt engineers) | $250K–$375K | — |
+| Generative AI Engineer (mid, KORE1) | $160K–$210K | $185K–$265K loaded |
+| AI Front End Developer (ZipRecruiter range) | $104K–$350K | — |
+
+**Signal:** At Rob's Staff level with demonstrable AI workflow velocity and product delivery at scale, $220K–$320K total comp is a realistic and well-supported target at well-funded startups. FAANG-adjacent roles could push $400K+.
+
+---
+
+## Implications for Rob's Positioning
+
+### Title Recommendation: **Staff Software Engineer** (primary) + **AI-Native Product Engineer** (subtitle/narrative)
+- "Staff Frontend Engineer" is searchable and credible — don't abandon it.
+- "Agentic Engineer" alone risks being pigeonholed into ML infra roles he'd be underqualified for technically.
+- The **Augment Code framework** is the best lens for framing his differentiators: he matches all 6 AI-native dimensions, especially product taste and learning velocity (11 weeks, 472+ PRs, 2 major products).
+
+### What Makes Rob's Story Land in 2026
+1. **Velocity is quantifiable**: 472+ PRs in 11 weeks, 2 shipped products (WavePoint + Sherpa Studio) — this is the kind of throughput that the "companies shrunk from 12 to 8 people but shipped 30% more" narrative is about.
+2. **He's a practitioner, not a consumer**: Uses Claude Code (the #1 tool among staff+ engineers per Pragmatic Engineer), has built AI agent infrastructure (Sherpa/OpenClaw), not just used Copilot to autocomplete.
+3. **Product surface matters**: WavePoint has 6 native Swift apps + Next.js web. That's multi-platform shipping, not just vibe-coded demos.
+4. **Sherpa Studio as proof of taste**: An AI dev tooling product that emerged organically from workflow — exactly what the Augment Code "product & outcome taste" dimension rewards.
+
+### Titles to Test on Applications
+- **Primary:** Staff Software Engineer / Staff Frontend Engineer (for searchability)
+- **Subtitle or LinkedIn headline addition:** "AI-Native Product Engineering" or "AI-Augmented Fullstack"
+- **Avoid as primary title:** "Agentic Engineer" alone (too infra/ML-skewed without LLM pipeline depth)
+- **In narrative only (not title):** "11-week AI-native sprint," "agentic development workflow," "AI-accelerated product delivery"
+
+### Companies to Target
+1. **AI coding / devtools startups** (Augment Code, Cursor, Modal, Replit, etc.) — they get this story immediately
+2. **YC-funded product AI startups** with UI-heavy products (voice AI, workflow automation, consumer apps)
+3. **Established AI-adopting companies** (Zapier, Datadog, GitLab) — "Staff Frontend + AI" roles explicitly open
+4. **Meta / FAANG** "Software Engineer, AI Native" track — real title now, needs strong portfolio
+5. **Consulting clients** (Deloitte/Accenture pattern) — they're building Agentic AI teams; Rob as a contractor/consultant fits
+
+---
+
+## Sources
+
+1. Augment Code – How we hire AI-native engineers now: https://www.augmentcode.com/blog/how-we-hire-ai-native-engineers-now
+2. Pragmatic Engineer – AI Tooling for Software Engineers in 2026: https://newsletter.pragmaticengineer.com/p/ai-tooling-2026
+3. Second Talent – How AI Is Changing Engineering Talent Demand in 2026: https://www.secondtalent.com/resources/how-ai-is-changing-engineering-talent-demand/
+4. KORE1 – How to Hire Generative AI Engineers in 2026: https://www.kore1.com/hire-generative-ai-engineers/
+5. KORE1 – AI Engineer Salary Guide 2026: https://www.kore1.com/ai-engineer-salary-guide/
+6. Glassdoor – Staff Frontend Engineer Salary 2026: https://www.glassdoor.com/Salaries/staff-frontend-engineer-salary-SRCH_KO0,23.htm
+7. Glassdoor – AI Engineer Salary 2026: https://www.glassdoor.com/Salaries/ai-engineer-salary-SRCH_KO0,11.htm
+8. ZipRecruiter – Staff Frontend Engineer Salary: https://www.ziprecruiter.com/Salaries/Staff-Frontend-Engineer-Salary
+9. Levels.fyi – AI Engineer Salary: https://www.levels.fyi/t/software-engineer/title/ai-engineer
+10. Levels.fyi – OpenAI Software Engineer Salary: https://www.levels.fyi/companies/openai/salaries/software-engineer
+11. Exceeds.ai – AI Engineer Salary 2026: https://blog.exceeds.ai/ai-engineer-salary/
+12. NuCamp – Top 10 Highest-Paying Frontend/Fullstack Jobs 2026: https://www.nucamp.co/blog/top-10-highest-paying-full-stack-and-frontend-jobs-in-2026-salary-breakdown
+13. Meta job posting – Software Engineer, AI Native: https://www.ziprecruiter.com/c/Meta/Job/Software-Engineer,-AI-Native/-in-New-York,NY?jid=eb250fd9b239140a
+14. Citi job posting – Agentic AI Engineer, VP: https://jobs.citi.com/job/tampa/agentic-ai-engineer-vice-president/287/92572658384
+15. Deloitte job posting – Agentic AI Engineer Consultant: https://usijobs.deloitte.com/en_US/careersUSI/JobDetail/USI-EH26-Consulting-Services-AI-E-EaaS-SWE-Consultant-Agentic-AI-Engineer/317603
+16. Accenture – Google Agentic AI Delivery Specialist: https://www.accenture.com/us-en/careers/jobdetails?id=R00306801_en
+17. T-Mobile – Full Stack Principal Software Engineer, Gen AI: https://careers.t-mobile.com/full-stack-principal-software-engineer-gen-ai/job/74542D3F937BD256F6B182F82155BF0C
+18. YC Companies Hiring (AI, SF): https://www.ycombinator.com/companies/industry/ai/san-francisco-bay-area/hiring
+19. Authentic Jobs – Frontend to AI Career Guide: https://authenticjobs.com/frontend-developer-to-ai-developer-career-guide/
+20. HN Hiring March 2026 (React jobs): https://hnhiring.com/technologies/react
+21. Web3.career – Remote React Jobs (JD excerpt): https://web3.career/react+remote-jobs
+22. Let's Data Science – AI Engineer Roadmap 2026: https://letsdatascience.com/blog/ai-engineer-roadmap-2026-skills-tools-and-career-path
+23. Yallo – Future of AI Jobs in 2026: https://yallo.co/insights/news/future-of-ai-jobs-2026/
+24. startup.jobs – AI roles: https://startup.jobs/artificial-intelligence-jobs


### PR DESCRIPTION
Nightly job market research. See `.sherpa/research/job-market/2026-03-21.md`

## Summary
Comprehensive survey of the AI-native / agentic engineering job landscape as of March 2026.

**Key findings:**
- "Agentic AI Engineer" is a real title (Citi, Deloitte, Accenture) but skews ML/infra — not a great primary title for Rob without LLM pipeline depth
- "AI-Native Engineer" is a hiring lens, not a widely searchable title — Meta is using "Software Engineer, AI Native" (posted Feb 2026)
- Staff Frontend + AI workflow expertise commands 20–40% salary premium; 20K–50K total comp realistic target at well-funded startups
- Claude Code is now the #1 AI dev tool among staff+ engineers (95% weekly AI usage, 56% doing 70%+ work with AI)
- Rob's 472-PR / 11-week velocity story maps perfectly to the Augment Code "6 dimensions of AI-native engineering" framework

**Recommendation:** Keep "Staff Software Engineer" as primary searchable title; use "AI-Native Product Engineering" as narrative/subtitle. Target AI devtools startups and YC-funded product AI companies first.