### PR TITLE
feat: research framework — priorities, state, heartbeat

### DIFF
--- a/.sherpa/research/PRIORITIES.md
+++ b/.sherpa/research/PRIORITIES.md
@@ -1,0 +1,40 @@
+# Research Priorities
+
+Last updated: 2026-03-21 by Rob
+
+## The Narrative
+
+I am positioning Sherpa (consulting practice) and WavePoint (product) as my most recent roles — Founder & Principal Engineer at both. I built these using agentic engineering, and then built Sherpa Studio, an Agentic Engineering workflow suite, as the tooling layer that powered that velocity. This, combined with my previous experience as a Staff Frontend Engineer, should be a strong enough signal to land a new role quickly.
+
+The throughline: **I didn't just use AI tools — I built the infrastructure, shipped production products, and founded a consulting practice around it.**
+
+## Current Priorities (ordered)
+
+### 1. Cohesive Professional Narrative & Story
+- The story across robabby.com, LinkedIn, resume, Sherpa site, and WavePoint needs to read as one coherent arc
+- Someone landing on any surface should understand: who Rob is, what he built, why it matters, and that he's available
+- Tone: confident, specific, outcomes-first. Not buzzwordy.
+- Key proof points: 472+ PRs in 11 weeks, 6 native Swift apps, full Next.js web platform, AI dev tooling product, consulting practice with foundation stone
+
+### 2. Sherpa Consulting Website
+- Content and pages need tightening — this is a consulting practice site, not a product page
+- Should reflect the foundation stone values: honesty, craftsmanship, empowerment, integrity, community
+- Should position Rob as a credible AI transformation consultant
+- Services, approach, case studies (WavePoint as the proof-of-concept)
+
+### 3. Resume, LinkedIn, robabby.com Updates
+- Add Sherpa (Founder & Principal Engineer) as most recent position
+- Add Sherpa Studio as a key project/product within that role
+- Add WavePoint (Founder & Principal Engineer) as previous/concurrent role
+- Update robabby.com project showcases to reflect current state
+- LinkedIn headline and summary need to match the narrative
+
+## What Research Should Focus On
+
+Research should actively support these priorities:
+- How do other founder-engineers present consulting + product work on resumes?
+- What do the best engineering portfolio sites look like in 2026?
+- How are people framing "AI-native development" in their professional narrative?
+- What are hiring managers actually looking for when they review founder backgrounds?
+- Content strategy: what should Rob publish first to establish credibility?
+- Interview prep: for target companies, what questions and topics come up?

--- a/.sherpa/research/RESEARCH_STATE.md
+++ b/.sherpa/research/RESEARCH_STATE.md
@@ -1,0 +1,51 @@
+# Research State
+
+This file is maintained by Luna. It tracks what's been researched, what threads are dangling, and what the next heartbeat should consider.
+
+## Last Updated
+2026-03-21T16:57Z (initialization)
+
+## Coverage Map
+
+### Nightly Streams (automated, daily)
+| Stream | Last Run | Key Findings |
+|---|---|---|
+| job-market | 2026-03-21 | "Agentic AI Engineer" is real title; Meta uses "AI Native"; $195K-$350K+ senior range |
+| competitive | 2026-03-21 | Karpathy coined "agentic engineering"; Jeremy Ron King 367K lines solo; Swift+AI is rare |
+| target-companies | 2026-03-21 | Stripe deep dive — "Staff Frontend, AI Design Tooling" role is direct comp |
+| consulting | 2026-03-21 | First run — check output for initial landscape |
+| content-strategy | 2026-03-21 | First run — check output for platform analysis |
+| network | 2026-03-21 | First run — check community mapping |
+| studio-landscape | 2026-03-21 | First run — check dev tooling competitive landscape |
+| pnw-remote | 2026-03-21 | First run — check PNW/remote roles |
+
+### Heartbeat Research (adaptive, on-demand)
+| Date | Topic | Output | Trigger |
+|---|---|---|---|
+| — | — | — | (none yet) |
+
+## Dangling Threads
+These surfaced from nightly research and deserve deeper follow-up:
+
+1. **Stripe "Staff Frontend, AI Design Tooling" role** — Is it still open? Who's the hiring manager? What team? This is the single closest role match found so far.
+2. **Augment Code hiring criteria** — They published a rubric for "AI-native engineers" that maps almost perfectly to Rob's experience. Worth a deep dive into how to use their framework in applications.
+3. **Jeremy Ron King** — Most directly comparable story (solo, high velocity, agentic). What can Rob learn from how he tells it? Where did it get traction?
+4. **Founder-to-employee narrative** — How do other founders present returning to FTE? What works, what backfires?
+5. **Rob's first blog post** — Content strategy research should surface what to write first and where to publish for maximum impact.
+
+## Research Queue (for heartbeats)
+Ordered by current priority alignment:
+
+1. **Professional narrative audit** — Review robabby.com, LinkedIn, and resume as they exist now. Identify gaps vs. the story Rob wants to tell.
+2. **Founder-engineer resume patterns** — How do top engineers present founder/startup experience when re-entering the job market?
+3. **Consulting site best practices** — What do compelling solo AI consulting sites look like? Content, structure, trust signals.
+4. **Stripe deep dive follow-up** — Dig deeper into the specific role, team, and interview process.
+5. **First content piece validation** — What angle for Rob's first published article has the best chance of reach?
+6. **Portfolio site benchmarks** — Best engineering portfolio sites in 2026. Design patterns, content structure, what hiring managers actually click on.
+7. **LinkedIn optimization for job seekers** — Specific tactics for engineers in 2026.
+
+## Notes for Future Me
+- Read PRIORITIES.md first every heartbeat — Rob may have shifted focus
+- Check nightly output files for new signals worth adding to dangling threads
+- After completing a heartbeat research topic, update the queue and move completed items to the coverage map
+- Don't duplicate what nightly crons already cover — go deeper, not wider


### PR DESCRIPTION
Adds the adaptive research infrastructure that powers heartbeat-driven research cycles.

**PRIORITIES.md** — Rob's current focus areas. Edit anytime to shift research direction.
**RESEARCH_STATE.md** — Luna's tracking file. Coverage map, dangling threads, research queue.
**heartbeat/** — Output directory for adaptive on-demand research.

The nightly crons cover broad strokes. Heartbeats fill gaps, follow threads, and respond to shifting priorities.