### PR TITLE
Reposition portfolio narrative around Agentic Engineering

### DIFF
--- a/app/components/About.tsx
+++ b/app/components/About.tsx
@@ -3,16 +3,16 @@ import AnimatedSection from "./AnimatedSection";
 
 const ENGINEERING_PRINCIPLES = [
   {
-    title: "Systems that absorb complexity",
-    description: "Build the abstraction layer that makes the next 100 features — and the next 100 AI-generated contributions — safe to ship.",
+    title: "Build the tooling layer",
+    description: "Sherpa Studio exists because reliable AI development requires more than a capable model — it requires workforce management, skill orchestration, and convention enforcement at the infrastructure level.",
   },
   {
-    title: "AI as infrastructure, not shortcut",
-    description: "Governance rules, review gates, and structured workflows. The value is in the system around the model, not the model alone.",
+    title: "AI as a governed system, not a shortcut",
+    description: "Review gates, structured workflows, and clear boundaries. The value compounds when you treat AI as infrastructure you architect, not magic you invoke.",
   },
   {
-    title: "Ship the whole product",
-    description: "Architecture, APIs, native apps, payments, deployment. Staff-level thinking means owning the full surface, not just one layer.",
+    title: "Own the full surface",
+    description: "Consulting practice, product, native apps, APIs, tooling, deployment. Founding means shipping end-to-end — every layer, every decision.",
   },
 ];
 
@@ -37,7 +37,7 @@ export default function About() {
             <Box style={{ flex: 1 }}>
               {/* Editorial lead statement */}
               <Text className="about-lead" mb="6" style={{ display: "block" }}>
-                I build products at the intersection of systems engineering and AI-augmented development — shipping complex, cross-platform software as a solo technical founder at a pace that used to require a team.
+                As the founder and principal engineer behind Sherpa and WavePoint, I&#39;ve built across consulting, product, and developer tooling — turning 13 years of frontend infrastructure expertise into a practice that ships complex software with the velocity of a team and the architectural rigor of a staff engineer.
               </Text>
 
               {/* Narrative paragraphs */}
@@ -46,7 +46,7 @@ export default function About() {
               </Text>
 
               <Text className="about-narrative" mb="6" style={{ display: "block" }}>
-                Now I&#39;m applying that infrastructure instinct to a new kind of engineering. With WavePoint, I&#39;m building a full product — Next.js web app, 6 native Apple apps, shared TypeScript packages, a Swift astronomy engine — solo, shipping 450+ commits in 9 weeks. The multiplier is a purpose-built AI development workflow: governance rules, worktree isolation, a custom MCP server, and a 5-level abstraction ladder that lets me operate at the scope of a small team while maintaining the architectural standards of a Staff engineer.
+                Now I&#39;m applying that infrastructure instinct to a new kind of engineering. I founded Sherpa, an AI consulting practice grounded in honesty and craftsmanship, then built WavePoint — a full astrology and spirituality platform spanning a Next.js web app, native Apple apps, shared TypeScript packages, and a Swift astronomy engine — shipping 472+ PRs in 11 weeks as both a product and a proof-of-concept for agentic engineering at scale. To make that possible, I built Sherpa Studio, an Agentic Engineering workflow suite handling workforce management, skill orchestration, and convention enforcement. The throughline: I didn&#39;t just use AI tools, I built the infrastructure that makes AI-assisted development reliable.
               </Text>
 
               {/* Engineering principles */}

--- a/app/components/Experience/index.tsx
+++ b/app/components/Experience/index.tsx
@@ -10,9 +10,9 @@ const EXPERIENCE = [
     companyLink: "https://wavepoint.space",
     period: "2026 — Present",
     featured: true,
-    description: "Solo technical founder of WavePoint, an intelligence-native astrology platform shipping a Next.js web app and 6 native Apple apps from a single monorepo. Built a purpose-designed AI-augmented development workflow that enables one engineer to operate at team-scale scope while maintaining Staff-level architectural standards.",
+    description: "Solo technical founder of WavePoint, an intelligence-native astrology platform shipping a Next.js web app and native Apple apps from a single monorepo. Built a purpose-designed AI-augmented development workflow that enables one engineer to operate at team-scale scope while maintaining Staff-level architectural standards.",
     highlights: [
-      "Shipped 450+ commits across a full-stack monorepo in 9 weeks — Next.js 16 web app, 6 native Apple apps (Swift/SwiftUI), 82 API routes, 37 computation modules, and 111 primitives as a solo engineer.",
+      "Shipped 450+ commits across a full-stack monorepo in 9 weeks — Next.js 16 web app, native Apple apps (Swift/SwiftUI), 82 API routes, 37 computation modules, and 111 primitives as a solo engineer.",
       "Designed and implemented a 44-rule AI governance system with auto-loading enforcement, worktree isolation, and a structured initiative workflow that ensures architectural consistency across all AI-generated contributions.",
       "Built a purpose-built MCP server with 12 composed tools following a Stripe-inspired 5-level abstraction ladder, replacing ad-hoc AI tooling with a principled interface design.",
       "Created a cross-platform 'Modern Mystic' design system spanning web (Radix UI, Tailwind) and native (SwiftUI) with shared TypeScript content packages bridging both surfaces.",

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -15,7 +15,7 @@ interface HeaderProps {
 const HOME_LINKS = [
   { href: "#home", label: "Home", isBrand: true },
   { href: "#about", label: "About" },
-  { href: "#featured-work", label: "Featured" },
+
   { href: "#skills", label: "Skills" },
   { href: "#experience", label: "Experience" },
   { href: "#case-studies", label: "Case Studies" },

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -47,7 +47,7 @@ export default function Hero() {
               <div className="hero-portrait-wrapper">
                 <Image
                   src="/profile.jpeg"
-                  alt="Rob Abby - Staff Engineer & AI-Augmented Builder"
+                  alt="Rob Abby - Staff Engineer & Agentic Engineering Practitioner"
                   width={300}
                   height={300}
                   priority
@@ -78,7 +78,7 @@ export default function Hero() {
                 transition={{ delay: 0.7, duration: 0.5, ease: "easeOut" }}
               >
                 <Text size="6" className="hero-title">
-                  Staff Engineer &amp; AI-Augmented Builder
+                  Staff Engineer &amp; Agentic Engineering Practitioner
                 </Text>
               </motion.div>
 
@@ -89,7 +89,7 @@ export default function Hero() {
                 transition={{ delay: 0.9, duration: 0.5, ease: "easeOut" }}
               >
                 <Text className="subtitle-refined hero-tagline">
-                  From Design Systems to Intelligence-Native Products
+                  From Design Systems to Agentic Engineering
                 </Text>
               </motion.div>
 

--- a/app/components/Skills.tsx
+++ b/app/components/Skills.tsx
@@ -39,7 +39,8 @@ const SKILL_CATEGORIES: Record<string, SkillCategory> = {
     featured: ["AWS", "Docker", "Living Design Systems", "AI-Augmented Development"],
     other: [
       "ECR", "ECS", "S3", "CloudWatch", "Route 53", "Figma", "Git & Github",
-      "CI/CD", "VS Code", "Claude Code", "Chrome DevTools", "Postman",
+      "CI/CD", "VS Code", "Claude Code", "OpenClaw", "Codex", "Gemini",
+      "Cursor", "GitHub Copilot", "Chrome DevTools", "Postman",
       "Jira", "Confluence", "Slack", "Zoom", "MCP / Agentic Workflows", "Swift / SwiftUI"
     ]
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,11 +18,11 @@ const instrumentSans = Instrument_Sans({
 });
 
 export const metadata = {
-  title: "Rob Abby - Staff Frontend Engineer",
-  description: "Staff Frontend Engineer with 15+ years building exceptional web experiences for startups and enterprises. Expert in React, TypeScript, and design systems.",
+  title: "Rob Abby - Staff Engineer & Agentic Engineering Practitioner",
+  description: "Staff Engineer & Agentic Engineering Practitioner with 15+ years building exceptional web experiences for startups and enterprises. Expert in React, TypeScript, and design systems.",
   metadataBase: new URL("https://robabby.com"),
   openGraph: {
-    title: "Rob Abby - Staff Frontend Engineer",
+    title: "Rob Abby - Staff Engineer & Agentic Engineering Practitioner",
     description: "15+ years building exceptional web experiences. Expert in React, TypeScript, and design systems. Available for opportunities.",
     url: "https://robabby.com",
     siteName: "Rob Abby",
@@ -31,7 +31,7 @@ export const metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Rob Abby - Staff Frontend Engineer",
+    title: "Rob Abby - Staff Engineer & Agentic Engineering Practitioner",
     description: "15+ years building exceptional web experiences. Expert in React, TypeScript, and design systems.",
   },
 }

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
 
-export const alt = "Rob Abby - Staff Frontend Engineer";
+export const alt = "Rob Abby - Staff Engineer & Agentic Engineering Practitioner";
 export const size = {
   width: 1200,
   height: 630,
@@ -58,7 +58,7 @@ export default async function Image() {
               marginBottom: 24,
             }}
           >
-            Staff Frontend Engineer
+            Staff Engineer & Agentic Engineering Practitioner
           </div>
 
           {/* Tagline */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Header from "./components/Header";
 import Hero from "./components/Hero";
 import StatsBar from "./components/StatsBar";
 import About from "./components/About";
-import FeaturedWork from "./components/FeaturedWork";
+
 import Skills from "./components/Skills";
 import Experience from "./components/Experience";
 import CaseStudies from "./components/CaseStudies";
@@ -17,7 +17,7 @@ export default function Home() {
       <Hero />
       <StatsBar />
       <About />
-      <FeaturedWork />
+
       <Skills />
       <Experience />
       <CaseStudies />


### PR DESCRIPTION
## Summary

- **Hero**: Updated title to "Staff Engineer & Agentic Engineering Practitioner", tagline to "From Design Systems to Agentic Engineering"
- **About**: Rewrote lead statement, second narrative paragraph (Sherpa + WavePoint + Sherpa Studio story, 472+ PRs in 11 weeks), and engineering principles to reflect agentic engineering positioning
- **Skills**: Added Claude Code, OpenClaw, Codex, Gemini, Cursor, GitHub Copilot to Platforms & Tools
- **Experience**: Removed "6" from native Apple apps count in WavePoint entry
- **Page metadata**: Updated page title, OpenGraph, Twitter cards, and OG image to "Staff Engineer & Agentic Engineering Practitioner"
- **Navigation**: Removed FeaturedWork section and "Featured" nav link

## Test plan

- [ ] Verify hero title and tagline render correctly
- [ ] Verify About section narrative reads well and principles display
- [ ] Verify Skills section shows new tools
- [ ] Verify header nav no longer shows "Featured" link
- [ ] Verify page title in browser tab
- [ ] Verify no broken links from removed FeaturedWork section

🤖 Generated with [Claude Code](https://claude.com/claude-code)