### PR TITLE
Restore FeaturedWork section and nav link

### DIFF
--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -15,7 +15,7 @@ interface HeaderProps {
 const HOME_LINKS = [
   { href: "#home", label: "Home", isBrand: true },
   { href: "#about", label: "About" },
-
+  { href: "#featured-work", label: "Featured" },
   { href: "#skills", label: "Skills" },
   { href: "#experience", label: "Experience" },
   { href: "#case-studies", label: "Case Studies" },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Header from "./components/Header";
 import Hero from "./components/Hero";
 import StatsBar from "./components/StatsBar";
 import About from "./components/About";
-
+import FeaturedWork from "./components/FeaturedWork";
 import Skills from "./components/Skills";
 import Experience from "./components/Experience";
 import CaseStudies from "./components/CaseStudies";
@@ -17,7 +17,7 @@ export default function Home() {
       <Hero />
       <StatsBar />
       <About />
-
+      <FeaturedWork />
       <Skills />
       <Experience />
       <CaseStudies />


### PR DESCRIPTION
## Summary

- Re-enables the WavePoint Featured Work showcase section on the homepage
- Restores the "Featured" link in the header navigation

## Test plan

- [ ] Verify Featured Work section renders between About and Skills
- [ ] Verify "Featured" nav link scrolls to the section

🤖 Generated with [Claude Code](https://claude.com/claude-code)