### PR TITLE
fix: reconcile stats to canonical 472+ PRs / 11 weeks

### DIFF
--- a/app/components/Experience/index.tsx
+++ b/app/components/Experience/index.tsx
@@ -12,7 +12,7 @@ const EXPERIENCE = [
     featured: true,
     description: "Solo technical founder of WavePoint, an intelligence-native astrology platform shipping a Next.js web app and native Apple apps from a single monorepo. Built a purpose-designed AI-augmented development workflow that enables one engineer to operate at team-scale scope while maintaining Staff-level architectural standards.",
     highlights: [
-      "Shipped 450+ commits across a full-stack monorepo in 9 weeks — Next.js 16 web app, native Apple apps (Swift/SwiftUI), 82 API routes, 37 computation modules, and 111 primitives as a solo engineer.",
+      "Shipped 472+ PRs across a full-stack monorepo in 11 weeks — Next.js 16 web app, native Apple apps (Swift/SwiftUI), 82 API routes, 37 computation modules, and 111 primitives as a solo engineer.",
       "Designed and implemented a 44-rule AI governance system with auto-loading enforcement, worktree isolation, and a structured initiative workflow that ensures architectural consistency across all AI-generated contributions.",
       "Built a purpose-built MCP server with 12 composed tools following a Stripe-inspired 5-level abstraction ladder, replacing ad-hoc AI tooling with a principled interface design.",
       "Created a cross-platform 'Modern Mystic' design system spanning web (Radix UI, Tailwind) and native (SwiftUI) with shared TypeScript content packages bridging both surfaces.",

--- a/app/components/FeaturedWork/index.tsx
+++ b/app/components/FeaturedWork/index.tsx
@@ -54,7 +54,7 @@ export default function FeaturedWork() {
 
             <Box style={{ flex: 1 }}>
               <Text className="about-lead" mb="4" style={{ display: "block" }}>
-                A cross-platform astrology product built solo with AI agents — 450+ commits in 9 weeks across a web app and 6 native Apple apps.
+                A cross-platform astrology product built solo with AI agents — 472+ PRs in 11 weeks across a web app and 6 native Apple apps.
               </Text>
               <Button size="2" variant="outline" asChild>
                 <a href="https://wavepoint.space" target="_blank" rel="noopener noreferrer">

--- a/app/components/StatsBar/index.tsx
+++ b/app/components/StatsBar/index.tsx
@@ -12,7 +12,7 @@ interface Stat {
 }
 
 const STATS: Stat[] = [
-  { value: 450, suffix: "+", label: "Commits in 9 Weeks" },
+  { value: 472, suffix: "+", label: "PRs in 11 Weeks" },
   { value: 6, suffix: "", label: "Native Apple Apps" },
   { value: 111, suffix: "", label: "Computation Primitives" },
   { value: 44, suffix: "", label: "Agentic Governance Rules" },


### PR DESCRIPTION
## What

Replaces all instances of `450+ commits in 9 weeks` with the correct canonical numbers across three components.

## Changes

| Component | Before | After |
|---|---|---|
| StatsBar | `450+` · `Commits in 9 Weeks` | `472+` · `PRs in 11 Weeks` |
| Experience | `450+ commits ... in 9 weeks` | `472+ PRs ... in 11 weeks` |
| FeaturedWork | `450+ commits in 9 weeks` | `472+ PRs in 11 weeks` |

## Why

- All cover letters, application materials, blog post draft, and LinkedIn playbook use **472+ PRs / 11 weeks**
- PRs are a stronger credibility signal than raw commits for engineering audiences (one PR = reviewed, merged, production-ready work)
- Having different numbers on the live site vs. every application is a red flag if a recruiter cross-checks

## Context

Identified in narrative audit (heartbeat research 2026-03-21). Blocked on reconciliation; now resolved before any applications go out.