### PR TITLE
feat: add vanity redirects for project domains

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,30 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: "/wavepoint",
+        destination: "https://wavepoint.space",
+        permanent: false,
+      },
+      {
+        source: "/sherpa",
+        destination: "https://sherpa.solar",
+        permanent: false,
+      },
+      {
+        source: "/vault",
+        destination: "https://ai-ready-vault.vercel.app",
+        permanent: false,
+      },
+      {
+        source: "/github",
+        destination: "https://github.com/robabby",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Adds robabby.com/{wavepoint,sherpa,vault,github} redirects. LinkedIn media links reject .space/.solar TLDs, so robabby.com paths front the project domains.