### PR TITLE
feat: experience section, hero portrait, and hireability quick wins

### DIFF
--- a/app/components/Splash.tsx
+++ b/app/components/Splash.tsx
@@ -12,7 +12,7 @@ const PROJECTS = [
   {
     name: "WavePoint",
     description:
-      "Product monorepo: a Next.js 16 web app with subscriptions, plus six native Apple apps sharing a Swift astronomy engine.",
+      "Solo-built product live in production: a Next.js 16 web app with subscriptions, plus six native Apple apps sharing a Swift astronomy engine — a 750+ commit monorepo.",
     stack: "Next.js 16 · TypeScript · Supabase · Stripe · SwiftUI",
     links: [
       { label: "Live site", href: "https://wavepoint.space" },
@@ -22,7 +22,7 @@ const PROJECTS = [
   {
     name: "Sherpa",
     description:
-      "Collaboration framework for agentic workflows — governance, research, and execution. Agent definitions, a skills engine, and a dispatch pipeline that live in your codebase.",
+      "Collaboration framework for agentic workflows that governs its own development — agent definitions, a skills engine, and a dispatch pipeline that live in your codebase.",
     stack: "Claude Code · Agentic workflows · TypeScript",
     links: [{ label: "Live site", href: "https://sherpa.solar" }],
   },
@@ -129,6 +129,7 @@ export default function Splash() {
               15 years shipping consumer and B2B products in React and
               TypeScript.
             </p>
+            <p className="proof">Previously: PartySlate · project44 · SAVO</p>
             <a
               className="cta"
               href="/resume.pdf"

--- a/app/components/Splash.tsx
+++ b/app/components/Splash.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { motion, useReducedMotion } from "motion/react";
 import ThemeToggle from "./ThemeToggle";
 
@@ -112,6 +113,14 @@ export default function Splash() {
       <main>
         <section className="splash">
           <motion.article className="card" {...fade}>
+            <Image
+              className="portrait"
+              src="/profile.jpeg"
+              alt=""
+              width={88}
+              height={88}
+              priority
+            />
             <p className="eyebrow">Bellingham, WA</p>
             <h1 className="name">Rob Abby</h1>
             <hr className="rule" aria-hidden />

--- a/app/components/Splash.tsx
+++ b/app/components/Splash.tsx
@@ -217,6 +217,16 @@ export default function Splash() {
         </motion.section>
         <footer className="footer">
           <p className="copyright">© {YEAR} Rob Abby</p>
+          <p className="colophon">
+            Designed &amp; built with Next.js ·{" "}
+            <a
+              href="https://github.com/robabby/robabby"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View source
+            </a>
+          </p>
         </footer>
       </main>
     </>

--- a/app/components/Splash.tsx
+++ b/app/components/Splash.tsx
@@ -44,6 +44,44 @@ const PROJECTS = [
   },
 ];
 
+const EXPERIENCE = [
+  {
+    company: "VIMSIA",
+    role: "Technology Strategist & IT Manager",
+    dates: "Mar 2025 – Nov 2025",
+    summary:
+      "Led technology strategy and AI integration for a PK-12 school; reduced support requests 20% through training and systems improvements.",
+  },
+  {
+    company: "PartySlate",
+    role: "Staff Engineer",
+    dates: "Dec 2018 – Feb 2024",
+    summary:
+      "Senior-most frontend engineer through growth from a 12-person startup to a 50+ employee Series-B company. Led the rewrite of Find Venues — the platform's highest-traffic page — driving a 150% increase in venue inquiries, and built the 25-module component library that cut feature rollout cycles 40% across teams.",
+  },
+  {
+    company: "project44",
+    role: "Senior UX Engineer",
+    dates: "Jun 2018 – Dec 2018",
+    summary:
+      "Built map-based logistics interfaces in a React/Redux codebase; established a living style guide and UI component library.",
+  },
+  {
+    company: "SAVO",
+    role: "Senior UI/UX & Product Developer",
+    dates: "Apr 2013 – Jun 2018",
+    summary:
+      "Led the spinout of an autonomous UI/UX team and a living design system informed by 50+ user research sessions; founded the org-wide Front-End Guild.",
+  },
+  {
+    company: "Web2Carz",
+    role: "Web Developer",
+    dates: "Nov 2011 – Mar 2013",
+    summary:
+      "Built consumer-facing galleries, forms, and a standalone mobile web app; introduced git and a formal deployment process.",
+  },
+];
+
 export default function Splash() {
   const reduceMotion = useReducedMotion();
   const fade = reduceMotion
@@ -59,6 +97,13 @@ export default function Splash() {
         initial: { opacity: 0, y: 8 },
         animate: { opacity: 1, y: 0 },
         transition: { duration: 0.6, ease: EASE, delay: 0.2 },
+      };
+  const fadeExp = reduceMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 8 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.6, ease: EASE, delay: 0.35 },
       };
 
   return (
@@ -109,9 +154,9 @@ export default function Splash() {
           aria-labelledby="work-heading"
           {...fadeWork}
         >
-          <p className="eyebrow" id="work-heading">
+          <h2 className="eyebrow" id="work-heading">
             Current Work
-          </p>
+          </h2>
           <p className="work-sub">
             Independent Software Engineer · Rob Abby LLC · Nov 2025 – Present
           </p>
@@ -119,7 +164,7 @@ export default function Splash() {
           <ul className="work-list">
             {PROJECTS.map((project) => (
               <li className="work-item" key={project.name}>
-                <h2 className="work-name">{project.name}</h2>
+                <h3 className="work-name">{project.name}</h3>
                 <p className="work-description">{project.description}</p>
                 <p className="work-stack">{project.stack}</p>
                 <p className="work-links">
@@ -136,6 +181,27 @@ export default function Splash() {
                     </span>
                   ))}
                 </p>
+              </li>
+            ))}
+          </ul>
+        </motion.section>
+        <motion.section
+          className="work"
+          aria-labelledby="experience-heading"
+          {...fadeExp}
+        >
+          <h2 className="eyebrow" id="experience-heading">
+            Experience
+          </h2>
+          <hr className="rule" aria-hidden />
+          <ul className="work-list">
+            {EXPERIENCE.map((job) => (
+              <li className="work-item" key={job.company}>
+                <h3 className="work-name">{job.company}</h3>
+                <p className="exp-meta">
+                  {job.role} · {job.dates}
+                </p>
+                <p className="work-description">{job.summary}</p>
               </li>
             ))}
           </ul>

--- a/app/globals.css
+++ b/app/globals.css
@@ -92,6 +92,7 @@ body {
   line-height: 1;
   color: var(--ink);
   margin: 0 0 1.5rem;
+  text-wrap: balance;
 }
 
 .rule {
@@ -120,6 +121,7 @@ body {
   max-width: 28rem;
   margin: 0 auto 2.75rem;
   line-height: 1.55;
+  text-wrap: balance;
 }
 
 .cta {
@@ -175,7 +177,12 @@ body {
 .links a:focus-visible {
   color: var(--ink);
   border-bottom-color: var(--ink);
-  outline: none;
+}
+
+.links a:focus-visible,
+.work-links a:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
 }
 
 .links span {
@@ -232,6 +239,7 @@ body {
   line-height: 1.55;
   max-width: 28rem;
   margin: 0 auto 0.75rem;
+  text-wrap: pretty;
 }
 
 .work-stack {
@@ -269,7 +277,6 @@ body {
 .work-links a:focus-visible {
   color: var(--ink);
   border-bottom-color: var(--ink);
-  outline: none;
 }
 
 .footer {
@@ -308,7 +315,11 @@ body {
 .theme-toggle:focus-visible {
   color: var(--ink);
   border-color: var(--ink);
-  outline: none;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
 }
 
 @media (max-width: 480px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -232,6 +232,14 @@ body {
   margin: 0 0 0.875rem;
 }
 
+.exp-meta {
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+  margin: 0 0 0.625rem;
+}
+
 .work-links {
   font-family: var(--font-body), sans-serif;
   font-size: 0.8125rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -121,9 +121,17 @@ body {
   font-weight: 400;
   color: var(--ink-muted);
   max-width: 28rem;
-  margin: 0 auto 2.75rem;
+  margin: 0 auto 1rem;
   line-height: 1.55;
   text-wrap: balance;
+}
+
+.proof {
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+  margin: 0 0 2.75rem;
 }
 
 .cta {
@@ -367,7 +375,7 @@ body {
     margin-bottom: 1.75rem;
   }
 
-  .tagline {
+  .proof {
     margin-bottom: 2.25rem;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,7 @@ body {
   --ink-muted: #5a5a5a;
   --ink-faint: #8a8a8a;
   --rule: #d4ccc0;
+  color-scheme: light;
 }
 
 [data-theme="dark"] {
@@ -25,6 +26,7 @@ body {
   --ink-muted: #a39c91;
   --ink-faint: #6b665d;
   --rule: #2a261f;
+  color-scheme: dark;
 }
 
 html {

--- a/app/globals.css
+++ b/app/globals.css
@@ -295,6 +295,34 @@ body {
   margin: 0;
 }
 
+.colophon {
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.6875rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0.625rem 0 0;
+}
+
+.colophon a {
+  color: var(--ink-muted);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1px;
+  transition: color 200ms ease, border-color 200ms ease;
+}
+
+.colophon a:hover,
+.colophon a:focus-visible {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+
+.colophon a:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+}
+
 .theme-toggle {
   position: fixed;
   top: 1.25rem;
@@ -361,6 +389,8 @@ body {
   body,
   .cta,
   .links a,
+  .work-links a,
+  .colophon a,
   .theme-toggle {
     transition: none;
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,16 @@ body {
   text-align: center;
 }
 
+.portrait {
+  display: block;
+  width: 88px;
+  height: 88px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--rule);
+  margin: 0 auto 1.5rem;
+}
+
 .eyebrow {
   font-family: var(--font-body), sans-serif;
   font-size: 0.6875rem;
@@ -304,6 +314,12 @@ body {
 @media (max-width: 480px) {
   .splash {
     padding: 1.5rem 1.25rem;
+  }
+
+  .portrait {
+    width: 72px;
+    height: 72px;
+    margin-bottom: 1.25rem;
   }
 
   .eyebrow {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "@radix-ui/themes/styles.css";
 import "./globals.css";
+import type { Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { Fraunces, Instrument_Sans } from "next/font/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -40,6 +41,30 @@ export const metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#faf7f2" },
+    { media: "(prefers-color-scheme: dark)", color: "#14110d" },
+  ],
+  colorScheme: "light dark",
+};
+
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Rob Abby",
+  jobTitle: "Senior Frontend Product Engineer",
+  url: "https://robabby.com",
+  image: "https://robabby.com/profile.jpeg",
+  email: "mailto:robabby23@gmail.com",
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Bellingham",
+    addressRegion: "WA",
+  },
+  sameAs: ["https://linkedin.com/in/robabby", "https://github.com/robabby"],
+};
+
 const themeScript = `(function(){try{var s=localStorage.getItem('theme');var d=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';document.documentElement.dataset.theme=s||d;}catch(e){document.documentElement.dataset.theme='dark';}})();`;
 
 export default function RootLayout({
@@ -53,6 +78,10 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className={`${fraunces.variable} ${instrumentSans.variable}`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+        />
         <ThemeProvider>{children}</ThemeProvider>
         <Analytics />
         <SpeedInsights />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: "https://robabby.com/sitemap.xml",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://robabby.com",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Design/hireability review quick wins for the active application window. Closes the launch plan's P1 gap (the site claimed 15 years but showed only Nov 2025–present) and fixes accessibility/SEO issues found in a Web Interface Guidelines review.

- **Experience section** — five prior roles (VIMSIA, PartySlate, project44, SAVO, Web2Carz) mirrored exactly from `resume.pdf`, reusing the existing `.work-*` styles. PartySlate carries the metrics (12→50+ Series B, Find Venues +150% inquiries, 25-module library / 40% faster rollouts).
- **Hero portrait** — circular `profile.jpeg` via `next/image` (priority, sized, no CLS).
- **Proof strip** — "Previously: PartySlate · project44 · SAVO" registers in the 5-second scan.
- **Heading hierarchy** — section labels promoted to real `h2`s, item names demoted to `h3` (zero visual change; classes carry all styling).
- **Focus states** — removed `outline: none` from contact links, project links, and theme toggle; all now show the CTA's visible outline pattern.
- **SEO** — `robots.ts`, `sitemap.ts`, schema.org Person JSON-LD, `theme-color` meta pair, `color-scheme` tracking the theme toggle.
- **Colophon** — "Designed & built with Next.js · View source" footer line linking to this repo.
- **Copy** — WavePoint leads with "solo-built, live in production, 750+ commits"; Sherpa leads with "governs its own development". All claims sourced from the resume.

## Verification

- `pnpm lint` and `pnpm build` clean; `/robots.txt` and `/sitemap.xml` generate.
- Rendered HTML checked: one `h1`, two `h2`s, `h3` items, JSON-LD and theme-color present.
- Playwright screenshots at 1440px/375px in light and dark: no layout breakage, fade-ins intact.
- Note: `prefers-reduced-motion` and keyboard-tab pass verified in CSS/markup; worth a quick manual spot-check on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)