### PR TITLE
feat(analytics): add Google Analytics 4 (SG-365)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Google Analytics 4 — Measurement ID for the robabby.com web stream.
+#
+# Public by design: this value ships in client-side JS on every page, so it is
+# not a secret. It lives here and in Vercel env for configurability, and in
+# .env.local for local use.
+#
+# When set, GA loads in every environment — including `pnpm dev` — so local
+# traffic would land in the live GA property. Leave it commented here so fresh
+# clones don't report to the live property by default.
+#
+# NEXT_PUBLIC_GA_ID="G-LWJLZT363L"

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/components/Splash.tsx
+++ b/app/components/Splash.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { motion, useReducedMotion } from "motion/react";
 import ThemeToggle from "./ThemeToggle";
 
@@ -219,7 +220,8 @@ export default function Splash() {
               rel="noopener noreferrer"
             >
               View source
-            </a>
+            </a>{" "}
+            · <Link href="/privacy">Privacy</Link>
           </p>
         </footer>
       </main>

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -2,12 +2,15 @@
 
 import { SunIcon, MoonIcon } from "@radix-ui/react-icons";
 import { setThemeMode, useThemeMode } from "./useThemeMode";
+import { track, ANALYTICS_EVENTS } from "../lib/analytics";
 
 export default function ThemeToggle() {
   const theme = useThemeMode();
 
   const toggle = () => {
-    setThemeMode(theme === "dark" ? "light" : "dark");
+    const next = theme === "dark" ? "light" : "dark";
+    setThemeMode(next);
+    track(ANALYTICS_EVENTS.THEME_CHANGED, { theme: next });
   };
 
   return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -393,12 +393,96 @@ body {
   }
 }
 
+.legal {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 4.5rem;
+}
+
+.legal-back {
+  display: inline-block;
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-muted);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 1px;
+  margin-bottom: 2.5rem;
+  transition: color 200ms ease, border-color 200ms ease;
+}
+
+.legal-back:hover,
+.legal-back:focus-visible {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+
+.legal h1 {
+  font-family: var(--font-display), Georgia, serif;
+  font-size: clamp(2.25rem, 6vw, 3.25rem);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--ink);
+  margin: 0 0 0.75rem;
+}
+
+.legal-updated {
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+  margin: 0 0 2.75rem;
+}
+
+.legal h2 {
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin: 2.5rem 0 0.875rem;
+}
+
+.legal p {
+  font-family: var(--font-body), sans-serif;
+  font-size: 0.9375rem;
+  color: var(--ink-muted);
+  line-height: 1.65;
+  max-width: 32rem;
+  margin: 0 0 1rem;
+  text-wrap: pretty;
+}
+
+.legal a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 1px;
+  transition: color 200ms ease, border-color 200ms ease;
+}
+
+.legal a:hover,
+.legal a:focus-visible {
+  border-bottom-color: var(--ink);
+}
+
+.legal a:focus-visible,
+.legal-back:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   body,
   .cta,
   .links a,
   .work-links a,
   .colophon a,
+  .legal a,
+  .legal-back,
   .theme-toggle {
     transition: none;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import "@radix-ui/themes/styles.css";
 import "./globals.css";
-import type { Viewport } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/react";
 import { Fraunces, Instrument_Sans } from "next/font/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import ThemeProvider from "./components/ThemeProvider";
 
 const fraunces = Fraunces({
@@ -19,7 +20,7 @@ const instrumentSans = Instrument_Sans({
   display: "swap",
 });
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Rob Abby — Senior Frontend Product Engineer",
   description:
     "Senior Frontend Product Engineer with 15 years shipping consumer and B2B products in React and TypeScript. Bellingham, WA.",
@@ -85,6 +86,9 @@ export default function RootLayout({
         <ThemeProvider>{children}</ThemeProvider>
         <Analytics />
         <SpeedInsights />
+        {process.env.NEXT_PUBLIC_GA_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+        )}
       </body>
     </html>
   );

--- a/app/lib/analytics/events.ts
+++ b/app/lib/analytics/events.ts
@@ -1,0 +1,30 @@
+/**
+ * Analytics event catalog — the single source of truth for GA4 custom event
+ * names and their payload shapes. Pure types and constants with no runtime
+ * import of `@next/third-parties`, so it's safe to import from anywhere.
+ *
+ * GA4 enhanced measurement already captures page views, scrolls, and outbound
+ * clicks on its own, so this catalog only covers interactions GA can't infer.
+ */
+
+/**
+ * Canonical GA4 event names. The string *values* are the live event names in
+ * GA4 — renaming a value splits historical data, so treat them as stable. The
+ * `satisfies` clause is a compile-time guard (every value must be a known event
+ * name), while `as const` preserves the literal types so `THEME_CHANGED` is
+ * `"theme_changed"`, not `string`.
+ */
+export const ANALYTICS_EVENTS = {
+  THEME_CHANGED: "theme_changed",
+} as const satisfies Record<string, AnalyticsEventName>;
+
+/** Maps each event name to the exact properties recorded with it. */
+export interface AnalyticsEventProperties {
+  /** Visitor toggled the color theme via the header toggle. */
+  theme_changed: {
+    /** Theme the visitor switched to. */
+    theme: "light" | "dark";
+  };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventProperties;

--- a/app/lib/analytics/ga.ts
+++ b/app/lib/analytics/ga.ts
@@ -1,0 +1,22 @@
+import { sendGAEvent } from "@next/third-parties/google";
+import type { AnalyticsEventName, AnalyticsEventProperties } from "./events";
+
+/**
+ * GA4 measurement ID, inlined at build time from the environment. When it's
+ * unset (local dev without a key, or a preview without the var), `track()`
+ * no-ops — so analytics calls are safe to leave in components everywhere.
+ */
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+/**
+ * Send a typed custom event to GA4. Event names and payload shapes live in
+ * `./events`, so callers can't pass an unknown event or a mismatched payload.
+ * No-ops during SSR and whenever GA isn't configured.
+ */
+export function track<E extends AnalyticsEventName>(
+  event: E,
+  properties: AnalyticsEventProperties[E],
+) {
+  if (!GA_ID || typeof window === "undefined") return;
+  sendGAEvent("event", event, properties);
+}

--- a/app/lib/analytics/index.ts
+++ b/app/lib/analytics/index.ts
@@ -1,0 +1,3 @@
+export { track } from "./ga";
+export { ANALYTICS_EVENTS } from "./events";
+export type { AnalyticsEventName, AnalyticsEventProperties } from "./events";

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy — Rob Abby",
+  description:
+    "How robabby.com handles analytics and your data. The short version: anonymous, aggregate traffic stats via Google Analytics — no accounts, no ads, nothing sold.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="legal">
+      <Link href="/" className="legal-back">
+        ← Back
+      </Link>
+      <h1>Privacy</h1>
+      <p className="legal-updated">Last updated: June 2026</p>
+
+      <p>
+        robabby.com is a personal portfolio site. There are no accounts, no
+        sign-ins, and no newsletter — so there’s very little to say here. This
+        is the whole of it.
+      </p>
+
+      <h2>What’s collected</h2>
+      <p>
+        The site uses Google Analytics 4 to understand aggregate traffic — which
+        pages are viewed, roughly where visitors arrive from, and what kind of
+        device they’re on. This data is anonymous and reported in aggregate; it
+        isn’t used to identify you.
+      </p>
+
+      <h2>Cookies</h2>
+      <p>
+        Google Analytics sets first-party cookies to recognize repeat visits and
+        measure sessions. You can block or clear these anytime through your
+        browser settings without affecting how the site works.
+      </p>
+
+      <h2>Google as a processor</h2>
+      <p>
+        Analytics data is processed by Google. See{" "}
+        <a
+          href="https://policies.google.com/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google’s Privacy Policy
+        </a>{" "}
+        for how they handle it. You can opt out of Google Analytics across every
+        site with Google’s{" "}
+        <a
+          href="https://tools.google.com/dlpage/gaoptout"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          opt-out browser add-on
+        </a>
+        .
+      </p>
+
+      <h2>What’s not collected</h2>
+      <p>
+        No personal accounts, no form submissions, no advertising trackers, and
+        nothing sold or shared for marketing. The site is hosted on Vercel,
+        which collects standard request logs and privacy-friendly aggregate
+        analytics as part of hosting.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions? Email{" "}
+        <a href="mailto:robabby23@gmail.com">robabby23@gmail.com</a>.
+      </p>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.9",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.2.1",
     "@vercel/analytics": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@next/third-parties':
+        specifier: ^16.2.9
+        version: 16.2.9(next@16.0.10(@babel/core@7.29.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-icons':
         specifier: ^1.3.2
         version: 1.3.2(react@19.1.1)
@@ -410,6 +413,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.2.9':
+    resolution: {integrity: sha512-JZPGQRN8eQs2WMfBXOf6Zjrma+JIN0KyA24MvmIa3bUI4BwTaJ1UlxmYVc5ri6l30LQ8fPv6Kmx20447hCltrg==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2498,6 +2507,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2976,6 +2988,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.0.10':
     optional: true
+
+  '@next/third-parties@16.2.9(next@16.0.10(@babel/core@7.29.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      next: 16.0.10(@babel/core@7.29.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5345,6 +5363,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  third-party-capital@1.0.20: {}
 
   tinyglobby@0.2.15:
     dependencies:


### PR DESCRIPTION
## Summary

Wires **Google Analytics 4** into robabby.com, mirroring WavePoint's GA setup and right-sized for a single-page portfolio.

> **Why GA4 instead of PostHog?** The original plan was PostHog, but the PostHog plan caps the org at one project — which WavePoint already holds. GA4 sidesteps that with its own free property.

GA4 property: web stream "My website" → https://robabby.com · Measurement ID `G-LWJLZT363L`.

## What changed

- **`<GoogleAnalytics>`** (`@next/third-parties/google`) mounted in `app/layout.tsx`, guarded by `NEXT_PUBLIC_GA_ID` so it **no-ops when the key is unset**. Injects gtag.js and tracks App Router client-side navigations automatically.
- **Typed analytics module** (`app/lib/analytics/`): a `track()` wrapper over `sendGAEvent` + a small event catalog. The theme toggle now emits a `theme_changed` event. (GA enhanced measurement already covers page views, scrolls, and outbound clicks.)
- **`/privacy`** — a concise disclosure (GA cookies + Google as processor, opt-out link), linked from the footer. robabby had no legal page before this; styled to match the site's paper/ink design tokens.
- **`.env.example`** documents `NEXT_PUBLIC_GA_ID`, committed via a `!.env.example` gitignore exception. The measurement ID is public (ships in client-side JS), so it's not a secret — the live value stays in `.env.local` (gitignored) and Vercel env.
- Typed the layout `metadata` export as `Metadata` (clears a TS diagnostic).

## Verification

- ✅ `pnpm lint` — clean (exit 0)
- ✅ `npx tsc --noEmit` — clean
- ✅ `pnpm build` — succeeds; `/privacy` prerenders as static
- ✅ Prod server: gtag.js loads with `G-LWJLZT363L` on `/`, `/privacy` → HTTP 200, footer Privacy link present
- ✅ No secret committed; `.env.local` is gitignored

## Follow-ups (not in this PR)

- **Vercel env**: add `NEXT_PUBLIC_GA_ID=G-LWJLZT363L` to Production + Preview, then redeploy (NEXT_PUBLIC vars are build-time inlined).
- **Dev traffic**: with the key in `.env.local`, GA also fires during `pnpm dev`. Fine for verification; unset locally (or add a `NODE_ENV` guard) if you want dev traffic kept out of the property.

Closes SG-365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
